### PR TITLE
Multiplying Effect-Fluids bugfix

### DIFF
--- a/Assets/KoboldKare/Scripts/Kobold.cs
+++ b/Assets/KoboldKare/Scripts/Kobold.cs
@@ -418,9 +418,7 @@ public class Kobold : GeneHolder, IGrabbable, IPunObservable, IPunInstantiateMag
             ScriptableReagent reagent = ReagentDatabase.GetReagent(pair.id);
             float processedAmount = pair.volume;
             reagent.GetConsumptionEvent().OnConsume(this, reagent, ref processedAmount, ref consumedReagents, ref addbackReagents, ref genes, ref newEnergy);
-            pair.volume -= processedAmount;
         }
-        bellyContainer.AddMixRPC(contents, -1);
         bellyContainer.AddMixRPC(addbackReagents, -1);
         float overflowEnergy = Mathf.Max(newEnergy - GetMaxEnergy(), 0f);
         if (overflowEnergy != 0f) {


### PR DESCRIPTION
Since it already processes all the fluid content and those which cannot be processed will be added to the addBackReagents float, there's no need for adding the "unprocessed" volume again.