### PR TITLE
Allow further eggs without exiting and re-entering station

### DIFF
--- a/Assets/KoboldKare/Scripts/OvipositionSpot.cs
+++ b/Assets/KoboldKare/Scripts/OvipositionSpot.cs
@@ -20,13 +20,20 @@ public class OvipositionSpot : GenericUsable, IAnimationStationSet {
 
     private ScriptableReagent egg;
     private ReadOnlyCollection<AnimationStation> readOnlyStations;
+    
+    private float lastEggCheckTime = 0;
+    private const float eggDelaySeconds = 6f;
 
     public override Sprite GetSprite(Kobold k) {
         return useSprite;
     }
     
+    private bool KoboldReadyToLayEgg(Kobold k){
+        return k.bellyContainer.GetVolumeOf(egg) > 5f && k.GetEnergy() >= 1f;
+    }
+    
     public override bool CanUse(Kobold k) {
-        return k.bellyContainer.GetVolumeOf(egg) > 5f && station.info.user == null && k.GetEnergy() >= 1f;
+        return KoboldReadyToLayEgg(k) && station.info.user == null;
     }
 
     public override void LocalUse(Kobold k) {
@@ -34,8 +41,13 @@ public class OvipositionSpot : GenericUsable, IAnimationStationSet {
         k.photonView.RPC(nameof(CharacterControllerAnimator.BeginAnimationRPC), RpcTarget.All, photonView.ViewID, 0);
     }
 
-    public override void Use() {
+    private void BeginEggLayingRoutine(){
+        lastEggCheckTime = Time.timeSinceLevelLoad + eggDelaySeconds;//don't bother checking again until the current one will be out
         StartCoroutine(EggLayingRoutine());
+    }
+    
+    public override void Use() {
+        BeginEggLayingRoutine();
     }
 
     void Start() {
@@ -45,8 +57,26 @@ public class OvipositionSpot : GenericUsable, IAnimationStationSet {
         egg = ReagentDatabase.GetReagent("Egg");
     }
 
+    void Update(){
+        if (Time.timeSinceLevelLoad-lastEggCheckTime < 3f) {
+            return;
+        }
+        lastEggCheckTime = Time.timeSinceLevelLoad;
+        
+        Kobold k = station.info.user;
+        if (k == null || !k.photonView.IsMine) {
+            return;
+        }
+        
+        if (!KoboldReadyToLayEgg(k)) {
+            return;
+        }
+        
+        BeginEggLayingRoutine();
+    }
+
     IEnumerator EggLayingRoutine() {
-        yield return new WaitForSeconds(6f);
+        yield return new WaitForSeconds(eggDelaySeconds);
         Kobold k = station.info.user;
         if (k == null || !k.photonView.IsMine) {
             yield break;


### PR DESCRIPTION
Hello, it's me from #100 ; I wound up losing the nerve to post about cum and eggs on my professional account, hahah.

I poked around at the possibility of the changes I'd mentioned, but I decided to start with something smaller; commit message below:

A kobold laying in an OvipositionSpot will now lay eggs whenever they're able, without having to stand up and "use" the OvipositionSpot a second time to continue.

Made it only check every 3 seconds since there's no particular rush, just in case it would be detrimental to run this every single frame (I haven't read up much on what goes under the hood of these checks yet), but if that's needlessly cautious I could take out the lastEggCheckTime part and just check for an egg-ready kobold every frame...   (Though, having the check wait on the eggDelaySeconds when starting laying also prevents eggs from 'doubling up' if enough cum still left in the belly has time to produce a high enough egg value that quickly, though I'm not sure if it's possible for that to happen faster than the six-second delay anyway....)

Was tempted to have the `if (!KoboldReadyToLayEgg(k))` check inside of EggLayingRoutine, rather than have the "is a kobold in the station" check duplicated inside and outside of it, but it felt a little unintuitive to be repeatedly firing off a coroutine that almost always immediately breaks, rather than just checking before firing it off....   It might be worth it to cut down on duplicate code, though.   Let me know if it would be better to change it.

This does allow for the possibility of a (gradual) 'endless eggs' scenario, although, given that any animation spot in the game can make endless hearts, I'd imagine that that's not a major concern...

Probably worth mentioning, I have not had the opportunity to test this in multiplayer whatsoever; I can't see anything here that suggests that it would have unique problems there, but this being my first change, there could absolutely be context I'm missing.  I've tested it relatively thoroughly in single-player though and it doesn't seem to have introduced any problems.