### PR TITLE
Prevent freecam movement from making kobolds jump and crouch

### DIFF
--- a/Assets/KoboldKare/Scripts/PlayerPossession.cs
+++ b/Assets/KoboldKare/Scripts/PlayerPossession.cs
@@ -270,6 +270,7 @@ public class PlayerPossession : MonoBehaviourPun {
         characterControllerAnimator.SetEyeRot(GetEyeRot());
     }
     public void OnJump(InputValue value) {
+        if (!isActiveAndEnabled) return;
         controller.inputJump = value.Get<float>() > 0f;
         if (!photonView.IsMine) {
             photonView.RequestOwnership();
@@ -290,6 +291,7 @@ public class PlayerPossession : MonoBehaviourPun {
         controller.inputWalking = value.Get<float>() > 0f;
     }
     public void OnCrouch(InputValue value) {
+        if (!isActiveAndEnabled) return;
         //controller.inputCrouched = value.Get<float>();
         controller.SetInputCrouched(value.Get<float>());
     }


### PR DESCRIPTION
Moving vertically in free cam is mapped to the same keys as jumping and crouching, and this was getting through even when input wasn't meant to be controlling the kobold. Honestly not sure exactly why this happens (or why it doesn't happen for other keys like R; possibly because that key isn't used in freecam mode?), but from what I can tell this fixes it -- though, this feels very much like a situation where it might not be this simple in multiplayer mode, which I haven't had the opportunity to test yet.  Still, I figure I'll at least toss this your way, and if it looks like how this should be addressed then great, and if not then hopefully you can point me in the direction of whatever root cause I should be tackling instead.