### PR TITLE
allow `/give machines` to give all unlocks

### DIFF
--- a/Assets/KoboldKare/Scripts/Cheats/CommandGive.cs
+++ b/Assets/KoboldKare/Scripts/Cheats/CommandGive.cs
@@ -68,6 +68,16 @@ public class CommandGive : Command {
             output.Append($"Gave 999 {args[1]} to {kobold.photonView.Owner.NickName}.\n");
             return;
         }
+        
+        if (args[1].ToLower() == "machines") {
+            var allContractsHolder = GameObject.Find("CityRegion/Shops/ConstructionOffice/Contracts");
+            var allContracts = allContractsHolder.GetComponentsInChildren<MachineConstructionContract>();
+            foreach(var curContract in allContracts) {
+                curContract.LocalUse(kobold);
+            }
+            output.Append($"Constructed all {allContracts.Length} machines.\n");
+            return;
+        }
 
         throw new CheatsProcessor.CommandException($"There is no prefab, reagent, or resource with name {args[1]}.");
     }

--- a/Assets/KoboldKare/Scripts/Cheats/CommandGive.cs
+++ b/Assets/KoboldKare/Scripts/Cheats/CommandGive.cs
@@ -70,12 +70,13 @@ public class CommandGive : Command {
         }
         
         if (args[1].ToLower() == "machines") {
-            var allContractsHolder = GameObject.Find("CityRegion/Shops/ConstructionOffice/Contracts");
-            var allContracts = allContractsHolder.GetComponentsInChildren<MachineConstructionContract>();
+            var allContracts = new List<MachineConstructionContract>();
+            allContracts.AddRange(GameObject.Find("CityRegion/Shops/ConstructionOffice/Contracts").GetComponentsInChildren<MachineConstructionContract>());
+            allContracts.AddRange(GameObject.Find("CaveRegion/CaveStuff/clownTent/TentContractsCanvas").GetComponentsInChildren<MachineConstructionContract>());
             foreach(var curContract in allContracts) {
                 curContract.LocalUse(kobold);
             }
-            output.Append($"Constructed all {allContracts.Length} machines.\n");
+            output.Append($"Constructed all {allContracts.Count} machines.\n");
             return;
         }
 


### PR DESCRIPTION
hardcoding the path isn't the cleanest thing, but it's probably fine for a cheat (won't cause anything catastrophic if it ever breaks). Works locally, but I haven't tested in multiplayer (but LocalUse seems to be the way to trigger things that propagate to the network?)