### PR TITLE
Small update to cheats

### DIFF
--- a/Assets/KoboldKare/Scripts/Cheats/CommandCum.cs
+++ b/Assets/KoboldKare/Scripts/Cheats/CommandCum.cs
@@ -1,3 +1,4 @@
+using Photon.Pun;
 using System.Text;
 
 [System.Serializable]
@@ -10,18 +11,12 @@ public class CommandCum : Command
         base.Execute(output, k, args);
         if (!CheatsProcessor.GetCheatsEnabled())
         {
-            throw new CheatsProcessor.CommandException("Cheats are not enabled, use `/cheats 1` to enable cheats.\n");
+            throw new CheatsProcessor.CommandException("Cheats are not enabled, use `/cheats 1` to enable cheats.");
         }
 
-        if (args.Length < 0 | args.Length > 2)
+        if (args.Length > 2 || (args.Length != 1 && !int.TryParse(args[1], out _)))
         {
-            throw new CheatsProcessor.CommandException("Usage: /cum <ballSize> or /cum\n");
-        }
-
-
-        if (args.Length != 1 && !int.TryParse(args[1], out _))
-        {
-            throw new CheatsProcessor.CommandException("You must supply a numeric value as the argument. /cum <ballSize>\n");
+            throw new CheatsProcessor.CommandException("Usage: /cum <ballSize> ; /cum");
         }
 
         if (args.Length == 2)
@@ -29,16 +24,13 @@ public class CommandCum : Command
             k.photonView.RequestOwnership();
             KoboldGenes genes = k.GetGenes();
             float initialBallSize = genes.ballSize;
-            float floatValue = float.Parse(args[1]);
-            genes.ballSize = floatValue;
-            k.SetGenes(genes);
-            k.Cum();
-            genes.ballSize = initialBallSize;
-            k.SetGenes(genes);
+            k.SetGenes(genes.With(ballSize: float.Parse(args[1])));
+            k.photonView.RPC(nameof(Kobold.Cum), RpcTarget.All);
+            k.SetGenes(genes.With(ballSize: initialBallSize));
         }
         else
         {
-            k.Cum();
+            k.photonView.RPC(nameof(Kobold.Cum), RpcTarget.All);
         }
 
     }

--- a/Assets/KoboldKare/Scripts/Cheats/CommandDick.cs
+++ b/Assets/KoboldKare/Scripts/Cheats/CommandDick.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
-using Unity.VisualScripting;
 
 public class DickUtilities
 {
@@ -61,12 +60,11 @@ public class CommandDick : Command
             }
             throw new CheatsProcessor.CommandException("Please supply a valid index or dick name. Use /dick list to list names.");
         }
-        else if (!DickUtilities.penisDatabase.GetInfoByName(args[1]).IsUnityNull())
+        else if (DickUtilities.penisDatabase.GetInfoByName(args[1]) != null)
         {
             var selectedPenis = DickUtilities.penisDatabase.GetInfoByName(args[1]);
-            byte byteValue = (byte)DickUtilities.penises.IndexOf(selectedPenis);
             k.photonView.RequestOwnership();
-            k.SetDickRPC(dickID: byteValue);
+            k.SetDickRPC(dickID: (byte)DickUtilities.penises.IndexOf(selectedPenis));
             output.AppendLine("Set dick to " + args[1] + ".");
             return;
         }

--- a/Assets/KoboldKare/Scripts/Cheats/CommandGene.cs
+++ b/Assets/KoboldKare/Scripts/Cheats/CommandGene.cs
@@ -33,7 +33,6 @@ public class CommandGene : Command
 {
     public override string GetArg0() => ("/gene");
 
-
     public override void Execute(StringBuilder output, Kobold k, string[] args)
     {
         base.Execute(output, k, args);
@@ -86,14 +85,28 @@ public class CommandGene : Command
                                 k.photonView.RPC(nameof(Kobold.SetEnergyRPC), RpcTarget.All, value);
                                 break;
                             }
+                        case "dickThickness":
+                            if (float.Parse(args[2]) > 100)
+                            {
+                                throw new CheatsProcessor.CommandException("dickThickness only accepts values from 0 - 100.");
+                            }
+                            else
+                            {
+                                k.SetGenes(genes.With(dickThickness: float.Parse(args[2]) / 100));
+                            }
+                            break;
                         default:
                             if (GeneUtilities.geneTypes[c] == "System.Byte")
                             {
-                                var value = byte.Parse(args[2]);
-                                FieldInfo info = GeneUtilities.geneType.GetField(GeneUtilities.geneList[c]);
-                                info.SetValue(genes, value);
-                                break;
-
+                                if (byte.TryParse(args[2], out byte value))
+                                {
+                                    FieldInfo info = GeneUtilities.geneType.GetField(GeneUtilities.geneList[c]);
+                                    info.SetValue(genes, value);
+                                }
+                                else
+                                {
+                                    throw new CheatsProcessor.CommandException("You must supply a value between 0 and 255 for " + args[1] + ".");
+                                }
                             }
                             else if (GeneUtilities.geneTypes[c] == "System.Single")
                             {


### PR DESCRIPTION
Sorry I meant to get this into the original PR but you were quick on the merge!

Cum Command - Use different calls and squished checks.

Gene Command - Add case for dThickness, as it only accepts 0 - 1.0 and add case for values over 255 when setting byte values.

Dick Command - Removed unnecessary directive and replaced method with null check.

Thanks discord members who provided suggestions & tested.

Fixes #165