### PR TITLE
Addition of CustomReagentConsumptionEvents

### DIFF
--- a/Assets/KoboldKare/Scripts/Reagents/CustomConsumptionDiscreteTrigger.cs
+++ b/Assets/KoboldKare/Scripts/Reagents/CustomConsumptionDiscreteTrigger.cs
@@ -1,0 +1,31 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[System.Serializable]
+public class CustomConsumptionDiscreteTrigger : ConsumptionDiscreteTrigger
+{
+    [Header("Effect Strength based off of \"Required Cumulative Reagent\" value")]
+    [Space(10f)]
+    [SerializeField, SerializeReference, SerializeReferenceButton]
+    private List<ReagentEffect> Effects;
+
+    protected override void OnTrigger(Kobold k, ScriptableReagent scriptableReagent, ref float amountProcessed,
+        ref ReagentContents reagentMemory, ref ReagentContents addBack, ref KoboldGenes genes, ref float energy)
+    {
+        foreach (var Effect in Effects)
+        {
+            Effect.Apply(k, requiredCumulativeReagent, ref genes, ref addBack, ref energy);
+        }
+        base.OnTrigger(k, scriptableReagent, ref amountProcessed, ref reagentMemory, ref addBack, ref genes, ref energy);
+    }
+
+    public override void OnValidate()
+    {
+        base.OnValidate();
+        foreach (var Effect in Effects)
+        {
+            Effect.OnValidate();
+        }
+    }
+}

--- a/Assets/KoboldKare/Scripts/Reagents/CustomConsumptionDiscreteTrigger.cs.meta
+++ b/Assets/KoboldKare/Scripts/Reagents/CustomConsumptionDiscreteTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 971d70f3ce4494245a8da3d06f9b8d3e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/Reagents/CustomReagentConsumptionEvent.cs
+++ b/Assets/KoboldKare/Scripts/Reagents/CustomReagentConsumptionEvent.cs
@@ -1,0 +1,32 @@
+using System.Collections;
+using System.Collections.Generic;
+using Photon.Pun;
+using UnityEngine;
+
+[System.Serializable]
+public class CustomReagentConsumptionEvent : ReagentConsumptionEvent
+{
+    [Header("Effect Strength based off of digested amount.")]
+    [Space(10f)]
+    [SerializeField, SerializeReference, SerializeReferenceButton]
+    private List<ModifyingReagentEffect> Effects;
+
+    public override void OnConsume(Kobold k, ScriptableReagent scriptableReagent, ref float amountProcessed,
+        ref ReagentContents reagentMemory, ref ReagentContents addBack, ref KoboldGenes genes, ref float energy)
+    {
+        foreach (var Effect in Effects)
+        {
+            Effect.Apply(k, amountProcessed, ref genes, ref addBack, ref energy);
+        }
+        base.OnConsume(k, scriptableReagent, ref amountProcessed, ref reagentMemory, ref addBack, ref genes, ref energy);
+    }
+
+    public override void OnValidate()
+    {
+        base.OnValidate();
+        foreach (var Effect in Effects)
+        {
+            Effect.OnValidate();
+        }
+    }
+}

--- a/Assets/KoboldKare/Scripts/Reagents/CustomReagentConsumptionEvent.cs.meta
+++ b/Assets/KoboldKare/Scripts/Reagents/CustomReagentConsumptionEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5478f975429d9dc4284e94c9b8cee134
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/Reagents/CustomReagentConsumptionMetabolize.cs
+++ b/Assets/KoboldKare/Scripts/Reagents/CustomReagentConsumptionMetabolize.cs
@@ -1,0 +1,31 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[System.Serializable]
+public class CustomReagentConsumptionMetabolize : ReagentConsumptionMetabolize
+{
+    [Header("Effect Strength based off of metabolized amount.")]
+    [Space(10f)]
+    [SerializeField, SerializeReference, SerializeReferenceButton]
+    private List<ModifyingReagentEffect> Effects;
+
+    public override void OnConsume(Kobold k, ScriptableReagent scriptableReagent, ref float amountProcessed,
+        ref ReagentContents reagentMemory, ref ReagentContents addBack, ref KoboldGenes genes, ref float energy)
+    {
+        base.OnConsume(k, scriptableReagent, ref amountProcessed, ref reagentMemory, ref addBack, ref genes, ref energy);
+        foreach (var Effect in Effects)
+        {
+            Effect.Apply(k, amountProcessed, ref genes, ref addBack, ref energy);
+        }
+    }
+
+    public override void OnValidate()
+    {
+        base.OnValidate();
+        foreach (var Effect in Effects)
+        {
+            Effect.OnValidate();
+        }
+    }
+}

--- a/Assets/KoboldKare/Scripts/Reagents/CustomReagentConsumptionMetabolize.cs.meta
+++ b/Assets/KoboldKare/Scripts/Reagents/CustomReagentConsumptionMetabolize.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e4832ef0cfb019c4b97507b8769e2a18
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/BallSizeReagentEffect.cs
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/BallSizeReagentEffect.cs
@@ -1,0 +1,12 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class BallSizeReagentEffect : ModifyingReagentEffect
+{
+    public override void Apply(Kobold k, float usedAmount, ref KoboldGenes genes, ref ReagentContents addBack, ref float energy)
+    {
+        genes = genes.With(ballSize: genes.ballSize + usedAmount * Multiplier);
+    }
+}
+

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/BallSizeReagentEffect.cs.meta
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/BallSizeReagentEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1d4c2e7ab5f7d5c43bdf939f1efb3777
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/BaseSizeReagentEffect.cs
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/BaseSizeReagentEffect.cs
@@ -1,0 +1,11 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class BaseSizeReagentEffect : ModifyingReagentEffect
+{
+    public override void Apply(Kobold k, float usedAmount, ref KoboldGenes genes, ref ReagentContents addBack, ref float energy)
+    {
+        genes = genes.With(baseSize: genes.baseSize + usedAmount * Multiplier);
+    }
+}

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/BaseSizeReagentEffect.cs.meta
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/BaseSizeReagentEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4ea4cd72396f2c84bb44575142fff28e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/BellySizeReagentEffect.cs
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/BellySizeReagentEffect.cs
@@ -1,0 +1,11 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class BellySizeReagentEffect : ModifyingReagentEffect
+{
+    public override void Apply(Kobold k, float usedAmount, ref KoboldGenes genes, ref ReagentContents addBack, ref float energy)
+    {
+        genes = genes.With(bellySize: genes.bellySize + usedAmount * Multiplier);
+    }
+}

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/BellySizeReagentEffect.cs.meta
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/BellySizeReagentEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9647faf3303c0a748a6beef0f41d3749
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/BreastSizeReagentEffect.cs
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/BreastSizeReagentEffect.cs
@@ -1,0 +1,11 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class BreastSizeReagentEffect : ModifyingReagentEffect
+{
+    public override void Apply(Kobold k, float usedAmount, ref KoboldGenes genes, ref ReagentContents addBack, ref float energy)
+    {
+        genes = genes.With(breastSize: genes.breastSize + usedAmount * Multiplier);
+    }
+}

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/BreastSizeReagentEffect.cs.meta
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/BreastSizeReagentEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 99972d690d175284db65573e9c8865dc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/BrightnessReagentEffect.cs
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/BrightnessReagentEffect.cs
@@ -1,0 +1,11 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class BrightnessReagentEffect : ModifyingReagentEffect
+{
+    public override void Apply(Kobold k, float usedAmount, ref KoboldGenes genes, ref ReagentContents addBack, ref float energy)
+    {
+        genes = genes.With(brightness: (byte)Mathf.Clamp(genes.brightness + (byte)(Mathf.CeilToInt(usedAmount * Multiplier)), 0, 255));
+    }
+}

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/BrightnessReagentEffect.cs.meta
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/BrightnessReagentEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e0a2fa96c8511e040a7b4860bbdfd82d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/ConversionReagentEffect.cs
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/ConversionReagentEffect.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[System.Serializable]
+public class ConversionReagentEffect : ModifyingReagentEffect
+{
+    [SerializeField, Tooltip("Reagent to convert the digested amount to.")]
+    private ScriptableReagent ConvertToReagent;
+
+    public override void Apply(Kobold k, float usedAmount, ref KoboldGenes genes, ref ReagentContents addBack, ref float energy)
+    {
+        addBack.AddMix(ConvertToReagent.GetReagent(usedAmount * Multiplier));
+    }
+
+    public override void OnValidate()
+    {
+        base.OnValidate();
+        if (Multiplier <= 0f)
+        {
+            Multiplier = 0.1f;
+        }
+    }
+}

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/ConversionReagentEffect.cs.meta
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/ConversionReagentEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: eb1a51d9c0615014694edb03b806de54
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/CumReagentEffect.cs
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/CumReagentEffect.cs
@@ -1,0 +1,13 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Photon.Pun;
+
+[System.Serializable]
+public class CumReagentEffect : ReagentEffect
+{
+    public override void Apply(Kobold k, float usedAmount, ref KoboldGenes genes, ref ReagentContents addBack, ref float energy)
+    {
+        k.photonView.RPC(nameof(Kobold.Cum), RpcTarget.All);
+    }
+}

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/CumReagentEffect.cs.meta
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/CumReagentEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 62e9283a707bd2942a0051c4570bf6f7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/DickSizeReagentEffect.cs
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/DickSizeReagentEffect.cs
@@ -1,0 +1,11 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DickSizeReagentEffect : ModifyingReagentEffect
+{
+    public override void Apply(Kobold k, float usedAmount, ref KoboldGenes genes, ref ReagentContents addBack, ref float energy)
+    {
+        genes = genes.With(dickSize: genes.dickSize + usedAmount * Multiplier);
+    }
+}

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/DickSizeReagentEffect.cs.meta
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/DickSizeReagentEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 39f07e1a42270114e9855de0c8ed2cc4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/DickThicknessReagentEffect.cs
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/DickThicknessReagentEffect.cs
@@ -1,0 +1,11 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class DickThicknessReagentEffect : ModifyingReagentEffect
+{
+    public override void Apply(Kobold k, float usedAmount, ref KoboldGenes genes, ref ReagentContents addBack, ref float energy)
+    {
+        genes = genes.With(dickThickness: Mathf.Clamp(genes.dickThickness + usedAmount * Multiplier, 0f, 1f));
+    }
+}

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/DickThicknessReagentEffect.cs.meta
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/DickThicknessReagentEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f63d210c804e5c2478f7383cc307bc66
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/FatSizeReagentEffect.cs
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/FatSizeReagentEffect.cs
@@ -1,0 +1,11 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class FatSizeReagentEffect : ModifyingReagentEffect
+{
+    public override void Apply(Kobold k, float usedAmount, ref KoboldGenes genes, ref ReagentContents addBack, ref float energy)
+    {
+        genes = genes.With(fatSize: genes.fatSize + usedAmount * Multiplier);
+    }
+}

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/FatSizeReagentEffect.cs.meta
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/FatSizeReagentEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9888b6d775b4ce8459d0f61998eb3272
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/FloaterReagentEffect.cs
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/FloaterReagentEffect.cs
@@ -1,0 +1,31 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Photon.Pun;
+
+[System.Serializable]
+public class FloaterReagentEffect : ReagentEffect
+{
+    [SerializeField]
+    private PhotonGameObjectReference floaterInfoPrefab;
+    [SerializeField]
+    private float Duration = 5;
+
+    public override void Apply(Kobold k, float usedAmount, ref KoboldGenes genes, ref ReagentContents addBack, ref float energy)
+    {
+        GameObject obj = PhotonNetwork.Instantiate(floaterInfoPrefab.photonName, k.transform.position + Vector3.up * 0.5f, Quaternion.identity);
+        obj.GetPhotonView().StartCoroutine(DestroyInSeconds(obj));
+    }
+
+    private IEnumerator DestroyInSeconds(GameObject obj)
+    {
+        yield return new WaitForSeconds(Duration);
+        PhotonNetwork.Destroy(obj);
+    }
+
+    public override void OnValidate()
+    {
+        base.OnValidate();
+        floaterInfoPrefab.OnValidate();
+    }
+}

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/FloaterReagentEffect.cs.meta
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/FloaterReagentEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 027d28cca6418da44978acc16f3c9cac
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/GrabCountReagentEffect.cs
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/GrabCountReagentEffect.cs
@@ -1,0 +1,11 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class GrabCountReagentEffect : ModifyingReagentEffect
+{
+    public override void Apply(Kobold k, float usedAmount, ref KoboldGenes genes, ref ReagentContents addBack, ref float energy)
+    {
+        genes = genes.With(grabCount: (byte)Mathf.Clamp(genes.grabCount + (byte)(Mathf.CeilToInt(usedAmount * Multiplier)), 1, 255));
+    }
+}

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/GrabCountReagentEffect.cs.meta
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/GrabCountReagentEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 465480f999e805349bc50ac7b980ccde
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/HueReagentEffect.cs
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/HueReagentEffect.cs
@@ -1,0 +1,11 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class HueReagentEffect : ModifyingReagentEffect
+{
+    public override void Apply(Kobold k, float usedAmount, ref KoboldGenes genes, ref ReagentContents addBack, ref float energy)
+    {
+        genes = genes.With(hue: (byte)Mathf.CeilToInt((genes.hue + usedAmount * Multiplier) % 255f));
+    }
+}

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/HueReagentEffect.cs.meta
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/HueReagentEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 76e2bfca925fb464eba281eceb1c994f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/LactateReagentEffect.cs
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/LactateReagentEffect.cs
@@ -1,0 +1,13 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Photon.Pun;
+
+[System.Serializable]
+public class LactateReagentEffect : ReagentEffect
+{
+    public override void Apply(Kobold k, float usedAmount, ref KoboldGenes genes, ref ReagentContents addBack, ref float energy)
+    {
+        k.photonView.RPC(nameof(Kobold.MilkRoutine), RpcTarget.All);
+    }
+}

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/LactateReagentEffect.cs.meta
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/LactateReagentEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3871f372807d0c94cb4c5d7999d727e5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/MaxEnergyReagentEffect.cs
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/MaxEnergyReagentEffect.cs
@@ -1,0 +1,11 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MaxEnergyReagentEffect : ModifyingReagentEffect
+{
+    public override void Apply(Kobold k, float usedAmount, ref KoboldGenes genes, ref ReagentContents addBack, ref float energy)
+    {
+        genes = genes.With(maxEnergy: genes.maxEnergy + usedAmount * Multiplier);
+    }
+}

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/MaxEnergyReagentEffect.cs.meta
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/MaxEnergyReagentEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fb329d1884c3d914b9626e642e47ab0c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/MetabolizeCapacityReagentEffect.cs
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/MetabolizeCapacityReagentEffect.cs
@@ -1,0 +1,12 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MetabolizeCapacityReagentEffect : ModifyingReagentEffect
+{
+    public override void Apply(Kobold k, float usedAmount, ref KoboldGenes genes, ref ReagentContents addBack, ref float energy)
+    {
+        genes = genes.With(metabolizeCapacitySize: genes.metabolizeCapacitySize + usedAmount * Multiplier);
+    }
+}
+

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/MetabolizeCapacityReagentEffect.cs.meta
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/MetabolizeCapacityReagentEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fb18ab7674be83a4a9b6f76cb4a4a6dd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/ModifyingReagentEffect.cs
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/ModifyingReagentEffect.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[System.Serializable]
+public abstract class ModifyingReagentEffect : ReagentEffect
+{
+    public float Multiplier = 1;
+
+    public override void OnValidate()
+    {
+        base.OnValidate();
+        if (Multiplier == 0f)
+        {
+            Multiplier = 0.1f;
+        }
+    }
+}

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/ModifyingReagentEffect.cs.meta
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/ModifyingReagentEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 710a1093ed1938d49b4ad301adb5ebfe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/ReagentEffect.cs
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/ReagentEffect.cs
@@ -1,0 +1,14 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[System.Serializable]
+public abstract class ReagentEffect
+{
+    public abstract void Apply(Kobold k, float usedAmount, ref KoboldGenes genes, ref ReagentContents addBack, ref float energy);
+
+    public virtual void OnValidate()
+    {
+
+    }
+}

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/ReagentEffect.cs.meta
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/ReagentEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 513d79315e2eaa744b7d9eeeb7299d39
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/SaturationReagentEffect.cs
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/SaturationReagentEffect.cs
@@ -1,0 +1,11 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class SaturationReagentEffect : ModifyingReagentEffect
+{
+    public override void Apply(Kobold k, float usedAmount, ref KoboldGenes genes, ref ReagentContents addBack, ref float energy)
+    {
+        genes = genes.With(saturation: (byte)Mathf.Clamp(genes.saturation + (byte)(Mathf.CeilToInt(usedAmount * Multiplier)), 0, 255));
+    }
+}

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/SaturationReagentEffect.cs.meta
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentEffects/SaturationReagentEffect.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d18d28df0db475f45b253497b1f78bea
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds 3 Custom ConsumptionEvents and 19 ReagentEffect classes.
Those allow creation of Growth/Shrink effects for modded reagents without a new scripts for each one of them.

The three CustomConsumptionEvents are inherited from the three main base ConsumptionEvents:

**CustomConsumptionDiscreteTrigger**
- Requires a certain amount of digested reagent before the effect(s) apply.
- Can have a limit of how often it may apply to a Kobold.
- Has access to three extra effects:
  - CumReagentEffect (causes the Kobold to Cum)
  - LactateReagentEffect (causes the Kobold to lactate)
  - FloaterReagentEffect (causes floating indicators, like the strength giving for example)
  
**CustomReagentConsumptionMetabolize**
- Metabolizes digested fluids to apply the effects.

**CustomReagentConsumptionEvent**
- Digests the fluids but still allows for effects to apply.

Kept the original errors in case of empty effects in the editor, still uncertain of the best approach here.