### PR TITLE
Fixes the issue that happens when you have many equipment mods

### DIFF
--- a/Assets/KoboldKare/Scripts/Cheats/CommandEquip.cs
+++ b/Assets/KoboldKare/Scripts/Cheats/CommandEquip.cs
@@ -28,7 +28,7 @@ public class CommandEquip : Command {
         if (tryEquipment != null) {
             output.Append($"Equipped {tryEquipment.name}.");
             kobold.photonView.RPC(nameof(KoboldInventory.PickupEquipmentRPC), RpcTarget.All,
-                EquipmentDatabase.GetID(tryEquipment), -1);
+                tryEquipment.name, -1);
             return;
         }
 

--- a/Assets/KoboldKare/Scripts/Equipment/EquipmentDatabase.cs
+++ b/Assets/KoboldKare/Scripts/Equipment/EquipmentDatabase.cs
@@ -13,57 +13,32 @@ public class EquipmentDatabase : MonoBehaviour {
             instance = this;
         }
         
-        equipmentSorter = new EquipmentSorter();
-        
         if (equipments.Count >= 256) {
             throw new UnityException("Too many equipment! Only 256 unique equipment allowed...");
         }
     }
-    private class EquipmentSorter : IComparer<Equipment> {
-        public int Compare(Equipment x, Equipment y) {
-            return String.Compare(x.name, y.name, StringComparison.InvariantCulture);
-        }
-    }
-    private EquipmentSorter equipmentSorter;
+    
     public static void AddEquipment(Equipment newEquipment) {
-        for (int i = 0; i < instance.equipments.Count; i++) {
-            var reagent = instance.equipments[i];
-            // Replace strategy
-            if (reagent.name == newEquipment.name) {
-                instance.equipments[i] = newEquipment;
-                instance.equipments.Sort(instance.equipmentSorter);
-                return;
-            }
+        if (instance.equipments.ContainsKey(newEquipment.name)) {
+            instance.equipments[newEquipment.name] = newEquipment;
+        } else {
+            instance.equipments.Add(newEquipment.name, newEquipment);
         }
-
-        instance.equipments.Add(newEquipment);
-        instance.equipments.Sort(instance.equipmentSorter);
     }
     
     public static void RemoveEquipment(Equipment equipment) {
-        if (instance.equipments.Contains(equipment)) {
-            instance.equipments.Remove(equipment);
+        if (instance.equipments.ContainsKey(equipment.name)) {
+            instance.equipments.Remove(equipment.name);
         }
     }
     
     public static Equipment GetEquipment(string name) {
-        foreach (var equipment in instance.equipments) {
-            if (equipment.name == name) {
-                return equipment;
-            }
+        if (instance.equipments.ContainsKey(name)) {
+            return instance.equipments[name];
         }
         throw new UnityException("Failed to find equipment with name " + name);
     }
-    public static Equipment GetEquipment(byte id) {
-        if (id >= instance.equipments.Count) {
-            Debug.LogError($"Failed to find equipment with id {id}, replaced it with first available equipment.");
-            return instance.equipments[0];
-        }
-        return instance.equipments[id];
-    }
-    public static byte GetID(Equipment equipment) {
-        return (byte)instance.equipments.IndexOf(equipment);
-    }
-    public static List<Equipment> GetEquipments() => instance.equipments;
-    public List<Equipment> equipments;
+    
+    public static List<Equipment> GetEquipments() => new List<Equipment>(instance.equipments.Values);
+    public Dictionary<string, Equipment> equipments = new Dictionary<string, Equipment>();
 }

--- a/Assets/KoboldKare/Scripts/KoboldInventory.cs
+++ b/Assets/KoboldKare/Scripts/KoboldInventory.cs
@@ -41,9 +41,9 @@ public class KoboldInventory : MonoBehaviourPun, IPunObservable, ISavable {
     }
 
     [PunRPC]
-    public void PickupEquipmentRPC(byte equipmentID, int groundPrefabID) {
+    public void PickupEquipmentRPC(string equipmentName, int groundPrefabID) {
         PhotonView view = PhotonNetwork.GetPhotonView(groundPrefabID);
-        Equipment equip = EquipmentDatabase.GetEquipment(equipmentID);
+        Equipment equip = EquipmentDatabase.GetEquipment(equipmentName);
         PickupEquipment(equip, view == null ? null : view.gameObject);
         PhotonProfiler.LogReceive(sizeof(short)+sizeof(int));
     }
@@ -103,7 +103,7 @@ public class KoboldInventory : MonoBehaviourPun, IPunObservable, ISavable {
             BitBuffer bitBuffer = new BitBuffer(4);
             bitBuffer.AddByte((byte)equipment.Count);
             foreach(Equipment e in equipment) {
-                bitBuffer.AddByte(EquipmentDatabase.GetID(e));
+                bitBuffer.AddString(e.name);
             }
             stream.SendNext(bitBuffer);
         } else {
@@ -111,7 +111,7 @@ public class KoboldInventory : MonoBehaviourPun, IPunObservable, ISavable {
             byte equipmentCount = data.ReadByte();
             staticIncomingEquipment.Clear();
             for(int i=0;i<equipmentCount;i++) {
-                staticIncomingEquipment.Add(EquipmentDatabase.GetEquipment(data.ReadByte()));
+                staticIncomingEquipment.Add(EquipmentDatabase.GetEquipment(data.ReadString()));
             }
             ReplaceEquipmentWith(staticIncomingEquipment);
             PhotonProfiler.LogReceive(data.Length);
@@ -122,8 +122,8 @@ public class KoboldInventory : MonoBehaviourPun, IPunObservable, ISavable {
         JSONArray equipments = new JSONArray();
         Debug.Log(equipment.Count);
         foreach(Equipment e in equipment) {
-            Debug.Log(EquipmentDatabase.GetID(e));
-            equipments.Add(EquipmentDatabase.GetID(e));
+            Debug.Log(e.name);
+            equipments.Add(e.name);
         }
         node["equipments"] = equipments;
     }
@@ -132,7 +132,7 @@ public class KoboldInventory : MonoBehaviourPun, IPunObservable, ISavable {
         JSONArray equipments = node["equipments"].AsArray;
         staticIncomingEquipment.Clear();
         for(int i=0;i<equipments.Count;i++) {
-            staticIncomingEquipment.Add(EquipmentDatabase.GetEquipment((byte)equipments[i].AsInt));
+            staticIncomingEquipment.Add(EquipmentDatabase.GetEquipment(equipments[i].Value));
         }
         ReplaceEquipmentWith(staticIncomingEquipment);
     }


### PR DESCRIPTION
When you have a lot of equipment mods, if you use the /equip command you get the wrong equipment, this can also affect mods equipments.

The easiest way to replicate this issue is by subscribing to every mod in the Steam workshop that contain equipments and try to equip equipments from the base game with the /equip command

With this fix that no longer happens but if you have a mod with duplicate equipment or equipments with the same name as other equipment mods you will not be able to load that or those mods in the mod list.