### PR TITLE
Increase Equipment limit with short

### DIFF
--- a/Assets/KoboldKare/Scripts/Equipment/EquipmentDatabase.cs
+++ b/Assets/KoboldKare/Scripts/Equipment/EquipmentDatabase.cs
@@ -27,10 +27,6 @@ public class EquipmentDatabase : MonoBehaviour {
 
     private EquipmentSorter equipmentSorter;
 
-    // Limit for the number of unique equipment
-    private const int MaxUniqueEquipment = 32767;
-
-    // Initialize equipments list in the constructor
     public EquipmentDatabase() {
         equipments = new List<Equipment>();
     }
@@ -45,18 +41,16 @@ public class EquipmentDatabase : MonoBehaviour {
             }
         }
 
-        // Initialize equipmentSorter in Awake
         equipmentSorter = new EquipmentSorter();
     }
 
     public static void AddEquipment(Equipment newEquipment) {
-        if (Instance.equipments.Count >= MaxUniqueEquipment) {
+        if (Instance.equipments.Count >= short.MaxValue) {
             throw new UnityException("Too many equipment! Only 32767 unique equipment allowed...");
         }
 
         for (int i = 0; i < Instance.equipments.Count; i++) {
             var reagent = Instance.equipments[i];
-            // Replace strategy
             if (reagent.name == newEquipment.name) {
                 Instance.equipments[i] = newEquipment;
                 Instance.equipments.Sort(Instance.equipmentSorter);

--- a/Assets/KoboldKare/Scripts/Equipment/EquipmentDatabase.cs
+++ b/Assets/KoboldKare/Scripts/Equipment/EquipmentDatabase.cs
@@ -6,64 +6,100 @@ using UnityEngine;
 
 public class EquipmentDatabase : MonoBehaviour {
     private static EquipmentDatabase instance;
-    public void Awake() {
-        if (instance != null) {
-            Destroy(this);
-        } else {
-            instance = this;
-        }
-        
-        equipmentSorter = new EquipmentSorter();
-        
-        if (equipments.Count >= 256) {
-            throw new UnityException("Too many equipment! Only 256 unique equipment allowed...");
+    public static EquipmentDatabase Instance {
+        get {
+            if (instance == null) {
+                instance = (EquipmentDatabase)FindObjectOfType(typeof(EquipmentDatabase));
+                if (instance == null) {
+                    GameObject go = new GameObject("EquipmentDatabase");
+                    instance = go.AddComponent<EquipmentDatabase>();
+                }
+            }
+            return instance;
         }
     }
+
     private class EquipmentSorter : IComparer<Equipment> {
         public int Compare(Equipment x, Equipment y) {
             return String.Compare(x.name, y.name, StringComparison.InvariantCulture);
         }
     }
+
     private EquipmentSorter equipmentSorter;
+
+    // Limit for the number of unique equipment
+    private const int MaxUniqueEquipment = 32767;
+
+    // Initialize equipments list in the constructor
+    public EquipmentDatabase() {
+        equipments = new List<Equipment>();
+    }
+
+    void Awake() {
+        if (instance == null) {
+            instance = this;
+            DontDestroyOnLoad(this.gameObject);
+        } else {
+            if (this != instance) {
+                Destroy(this.gameObject);
+            }
+        }
+
+        // Initialize equipmentSorter in Awake
+        equipmentSorter = new EquipmentSorter();
+    }
+
     public static void AddEquipment(Equipment newEquipment) {
-        for (int i = 0; i < instance.equipments.Count; i++) {
-            var reagent = instance.equipments[i];
+        if (Instance.equipments.Count >= MaxUniqueEquipment) {
+            throw new UnityException("Too many equipment! Only 32767 unique equipment allowed...");
+        }
+
+        for (int i = 0; i < Instance.equipments.Count; i++) {
+            var reagent = Instance.equipments[i];
             // Replace strategy
             if (reagent.name == newEquipment.name) {
-                instance.equipments[i] = newEquipment;
-                instance.equipments.Sort(instance.equipmentSorter);
+                Instance.equipments[i] = newEquipment;
+                Instance.equipments.Sort(Instance.equipmentSorter);
                 return;
             }
         }
 
-        instance.equipments.Add(newEquipment);
-        instance.equipments.Sort(instance.equipmentSorter);
+        Instance.equipments.Add(newEquipment);
+        Instance.equipments.Sort(Instance.equipmentSorter);
     }
-    
+
     public static void RemoveEquipment(Equipment equipment) {
-        if (instance.equipments.Contains(equipment)) {
-            instance.equipments.Remove(equipment);
+        if (Instance.equipments.Contains(equipment)) {
+            Instance.equipments.Remove(equipment);
         }
     }
-    
+
     public static Equipment GetEquipment(string name) {
-        foreach (var equipment in instance.equipments) {
+        foreach (var equipment in Instance.equipments) {
             if (equipment.name == name) {
                 return equipment;
             }
         }
         throw new UnityException("Failed to find equipment with name " + name);
     }
-    public static Equipment GetEquipment(byte id) {
-        if (id >= instance.equipments.Count) {
-            Debug.LogError($"Failed to find equipment with id {id}, replaced it with first available equipment.");
-            return instance.equipments[0];
+
+    public static Equipment GetEquipment(short id) {
+        if (id >= Instance.equipments.Count) {
+            Debug.LogError($"Failed to find equipment with id {id}, replaced it with the first available equipment.");
+            return Instance.equipments[0];
         }
-        return instance.equipments[id];
+        return Instance.equipments[id];
     }
-    public static byte GetID(Equipment equipment) {
-        return (byte)instance.equipments.IndexOf(equipment);
+
+    public static short GetID(Equipment equipment) {
+        return (short)Instance.equipments.IndexOf(equipment);
     }
-    public static List<Equipment> GetEquipments() => instance.equipments;
+
+    public static List<Equipment> GetEquipments() => Instance.equipments;
+
     public List<Equipment> equipments;
 }
+
+
+
+

--- a/Assets/KoboldKare/Scripts/KoboldInventory.cs
+++ b/Assets/KoboldKare/Scripts/KoboldInventory.cs
@@ -41,7 +41,7 @@ public class KoboldInventory : MonoBehaviourPun, IPunObservable, ISavable {
     }
 
     [PunRPC]
-    public void PickupEquipmentRPC(byte equipmentID, int groundPrefabID) {
+    public void PickupEquipmentRPC(short equipmentID, int groundPrefabID) {
         PhotonView view = PhotonNetwork.GetPhotonView(groundPrefabID);
         Equipment equip = EquipmentDatabase.GetEquipment(equipmentID);
         PickupEquipment(equip, view == null ? null : view.gameObject);
@@ -101,17 +101,17 @@ public class KoboldInventory : MonoBehaviourPun, IPunObservable, ISavable {
     public void OnPhotonSerializeView(PhotonStream stream, PhotonMessageInfo info) {
         if (stream.IsWriting) {
             BitBuffer bitBuffer = new BitBuffer(4);
-            bitBuffer.AddByte((byte)equipment.Count);
+            bitBuffer.AddShort((short)equipment.Count);
             foreach(Equipment e in equipment) {
-                bitBuffer.AddByte(EquipmentDatabase.GetID(e));
+                bitBuffer.AddShort(EquipmentDatabase.GetID(e));
             }
             stream.SendNext(bitBuffer);
         } else {
             BitBuffer data = (BitBuffer)stream.ReceiveNext();
-            byte equipmentCount = data.ReadByte();
+            short equipmentCount = data.ReadShort();
             staticIncomingEquipment.Clear();
             for(int i=0;i<equipmentCount;i++) {
-                staticIncomingEquipment.Add(EquipmentDatabase.GetEquipment(data.ReadByte()));
+                staticIncomingEquipment.Add(EquipmentDatabase.GetEquipment(data.ReadShort()));
             }
             ReplaceEquipmentWith(staticIncomingEquipment);
             PhotonProfiler.LogReceive(data.Length);
@@ -132,8 +132,9 @@ public class KoboldInventory : MonoBehaviourPun, IPunObservable, ISavable {
         JSONArray equipments = node["equipments"].AsArray;
         staticIncomingEquipment.Clear();
         for(int i=0;i<equipments.Count;i++) {
-            staticIncomingEquipment.Add(EquipmentDatabase.GetEquipment((byte)equipments[i].AsInt));
+            staticIncomingEquipment.Add(EquipmentDatabase.GetEquipment((short)equipments[i].AsInt));
         }
         ReplaceEquipmentWith(staticIncomingEquipment);
     }
 }
+


### PR DESCRIPTION
When you have a lot of equipment mods (256 equipment elements), if you use the /equip command you get the wrong equipment, this can also affect mods equipments.

The easiest way to replicate this is by subscribing almost every mod in the Steam workshop that contain equipments and try to equip equipments from the base game with the /equip command

This change increases the limit so this no longer happens