### PR TITLE
Adds blend shape list to skinned mesh equipment

### DIFF
--- a/Assets/KoboldKare/Scripts/Equipment/EquipmentSkinnedMesh.cs
+++ b/Assets/KoboldKare/Scripts/Equipment/EquipmentSkinnedMesh.cs
@@ -1,56 +1,42 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using JigglePhysics;
 using Naelstrof.Inflatable;
+using PenetrationTech;
 using UnityEngine;
 
 [CreateAssetMenu(fileName = "New SkinnedMeshEquipment", menuName = "Equipment/SkinnedMesh Equipment", order = 1)]
 public class EquipmentSkinnedMesh : Equipment {
-    [SerializeField] private GameObject prefabContainingSkinnedMeshRenderers;
-    private List<SkinnedMeshRenderer> targets;
-
-    private class BlendShapeCopier : MonoBehaviour {
-        public SkinnedMeshRenderer source;
-        private List<SkinnedMeshRenderer> targets;
-
-        void Awake() {
-            targets = new List<SkinnedMeshRenderer>(GetComponentsInChildren<SkinnedMeshRenderer>());
-        }
-
-        void Update() {
-            foreach (var target in targets) {
-                CopyBlendShapes(target);
-            }
-        }
-
-        void CopyBlendShapes(SkinnedMeshRenderer target) {
-            int blendShapeCount = source.sharedMesh.blendShapeCount;
-            for (int i = 0; i < blendShapeCount; i++) {
-                string blendShapeName = source.sharedMesh.GetBlendShapeName(i);
-                int sourceBlendShapeIndex = source.sharedMesh.GetBlendShapeIndex(blendShapeName);
-                int targetBlendShapeIndex = target.sharedMesh.GetBlendShapeIndex(blendShapeName);
-                if (sourceBlendShapeIndex != -1 && targetBlendShapeIndex != -1) {
-                    float weight = source.GetBlendShapeWeight(sourceBlendShapeIndex);
-                    target.SetBlendShapeWeight(targetBlendShapeIndex, weight);
-                }
-            }
-        }
-    }
-
+    [SerializeField]
+    private GameObject prefabContainingSkinnedMeshRenderers;
+    [SerializeField]
+    private SkinnedMeshTweak[] blendShapesToTweak;
     public override GameObject[] OnEquip(Kobold k, GameObject groundPrefab) {
         base.OnEquip(k, groundPrefab);
         SkinnedMeshRenderer targetSkinnedMesh = k.koboldBodyRenderers[0] as SkinnedMeshRenderer;
         GameObject instance = Instantiate(prefabContainingSkinnedMeshRenderers, k.transform);
         JiggleSkin jiggleSkin = k.GetComponent<JiggleSkin>();
         instance.name = name;
-        BlendShapeCopier copier = instance.AddComponent<BlendShapeCopier>();
-        copier.source = targetSkinnedMesh;
-        foreach (var skinnedMesh in instance.GetComponentsInChildren<SkinnedMeshRenderer>()) {
+        // Tweak - change blend shapes on equip
+        foreach (SkinnedMeshTweak blend in blendShapesToTweak)
+        {
+            foreach (SkinnedMeshRenderer mesh in k.koboldBodyRenderers)
+            {
+                Mesh m = mesh.sharedMesh;
+                int index = m.GetBlendShapeIndex(blend.blendShapeName);
+                if(index == -1) continue;
+                blend.originalShapeValue = mesh.GetBlendShapeWeight(index);
+                mesh.SetBlendShapeWeight(index, blend.shapeValue);
+            }
+        }
+        // - - - - - - - - - - - - 
+        foreach(var skinnedMesh in instance.GetComponentsInChildren<SkinnedMeshRenderer>()) {
             Transform[] newBoneList = new Transform[targetSkinnedMesh.bones.Length];
             for (int i = 0; i < targetSkinnedMesh.bones.Length; i++) {
                 newBoneList[i] = targetSkinnedMesh.bones[i];
             }
-
             skinnedMesh.bones = newBoneList;
             skinnedMesh.rootBone = targetSkinnedMesh.rootBone;
             k.koboldBodyRenderers.Add(skinnedMesh);
@@ -58,13 +44,11 @@ public class EquipmentSkinnedMesh : Equipment {
                 if (inflater is InflatableBreast inflatableBreast) {
                     inflatableBreast.AddTargetRenderer(skinnedMesh);
                 }
-
                 if (inflater is InflatableBelly belly) {
                     belly.AddTargetRenderer(skinnedMesh);
                 }
-
                 if (inflater is InflatableBlendShape inflatableBlendShape) {
-                    inflatableBlendShape.AddTargetRenderer(skinnedMesh);
+                   inflatableBlendShape.AddTargetRenderer(skinnedMesh);
                 }
             }
 
@@ -72,10 +56,7 @@ public class EquipmentSkinnedMesh : Equipment {
                 jiggleSkin.targetSkins.Add(skinnedMesh);
             }
         }
-
-        return new[] {
-            instance
-        };
+        return new[] { instance };
     }
 
     public override GameObject OnUnequip(Kobold k, bool dropOnGround = true) {
@@ -86,24 +67,43 @@ public class EquipmentSkinnedMesh : Equipment {
             if (jiggleSkin != null) {
                 jiggleSkin.targetSkins.Remove(skinnedMesh);
             }
-
             foreach (var inflater in k.GetAllInflatableListeners()) {
                 if (inflater is InflatableBreast inflatableBreast) {
                     inflatableBreast.RemoveTargetRenderer(skinnedMesh);
                 }
-
                 if (inflater is InflatableBelly belly) {
                     belly.RemoveTargetRenderer(skinnedMesh);
                 }
-
                 if (inflater is InflatableBlendShape inflatableBlendShape) {
-                    inflatableBlendShape.RemoveTargetRenderer(skinnedMesh);
+                   inflatableBlendShape.RemoveTargetRenderer(skinnedMesh);
                 }
             }
-
             k.koboldBodyRenderers.Remove(skinnedMesh);
         }
+        // Tweak - reset blend shapes on unequip
+        foreach (SkinnedMeshTweak blend in blendShapesToTweak)
+        {
+            foreach (SkinnedMeshRenderer mesh in k.koboldBodyRenderers)
+            {
+                Mesh m = mesh.sharedMesh;
+                int index = m.GetBlendShapeIndex(blend.blendShapeName);
+                if(index == -1) continue;
+                mesh.SetBlendShapeWeight(index, blend.originalShapeValue);
+            }
+        }
+        // - - - - - - - - - - - - 
         Destroy(search.gameObject);
         return base.OnUnequip(k, dropOnGround);
     }
+}
+
+[System.Serializable]
+public class SkinnedMeshTweak
+{
+    [SerializeField]
+    public string blendShapeName;
+    [SerializeField] [Range(0.0f, 100.0f)]
+    public float shapeValue;
+    [NonSerialized] 
+    public float originalShapeValue = 0;
 }


### PR DESCRIPTION
Allows equipped skinned mesh items to set specific blend shapes in a kobold, reverting them to their original values after being unequipped.

As one would expect, these changes do not play nicely with constantly updating blends such as inflation, breast size and weight gain