### PR TITLE
Allows penetrables to opt in or out of self-penetration

### DIFF
--- a/Assets/KoboldKare/Scripts/Kobold.cs
+++ b/Assets/KoboldKare/Scripts/Kobold.cs
@@ -23,6 +23,7 @@ public class Kobold : GeneHolder, IGrabbable, IPunObservable, IPunInstantiateMag
         public Rigidbody ragdollAttachBody;
         public bool isFemaleExclusiveAnatomy = false;
         public bool canLayEgg = true;
+        public bool isSelfPenetrableOnRagdoll = false;
     }
 
     public delegate void EnergyChangedAction(float value, float maxValue);

--- a/Assets/KoboldKare/Scripts/Ragdoller.cs
+++ b/Assets/KoboldKare/Scripts/Ragdoller.cs
@@ -228,9 +228,14 @@ public class Ragdoller : MonoBehaviourPun, IPunObservable, ISavable, IOnPhotonVi
 
         foreach (var dickSet in kobold.activeDicks) {
             foreach (var penn in kobold.penetratables) {
-                if (!penn.penetratable.name.Contains("Mouth")) {
+                // Legacy. Mouths are always un-ignored on ragdoll then re-added later.
+                if (penn.penetratable.name.Contains("Mouth"))
+                {
+                    dickSet.dick.RemoveIgnorePenetrable(penn.penetratable);
                     continue;
                 }
+                // Bool system. (Un)Ignores penetrables based on a bool inside kobold.cs
+                if (!penn.isSelfPenetrableOnRagdoll) { continue; }
 
                 dickSet.dick.RemoveIgnorePenetrable(penn.penetratable);
             }
@@ -301,9 +306,14 @@ public class Ragdoller : MonoBehaviourPun, IPunObservable, ISavable, IOnPhotonVi
         transform.position += Vector3.up*0.5f;
         foreach (var dickSet in kobold.activeDicks) {
             foreach (var penn in kobold.penetratables) {
-                if (!penn.penetratable.name.Contains("Mouth")) {
+                // Legacy. Mouths are always un-ignored on ragdoll then re-added later.
+                if (penn.penetratable.name.Contains("Mouth"))
+                {
+                    dickSet.dick.AddIgnorePenetrable(penn.penetratable);
                     continue;
                 }
+                // Bool system. (Un)Ignores penetrables based on a bool inside kobold.cs
+                if (!penn.isSelfPenetrableOnRagdoll) { continue; }
 
                 dickSet.dick.AddIgnorePenetrable(penn.penetratable);
             }


### PR DESCRIPTION
Adds a boolean value to the kobold script that allows modders to choose whether or not a character will be able to penetrate themselves through specific holes when they ragdoll

-DISCLAIMER-
To allow legacy systems to still function as they did before this update, any penetrable with "Mouth" in its name will overlook these changes and be dynamically made penetrable when a character ragdolls regardless of this option's value.