### PR TITLE
Bug fixes: Permanent ragdoll & skinnedmesh equipment lag

### DIFF
--- a/Assets/KoboldKare/Scripts/PlayerPossession.cs
+++ b/Assets/KoboldKare/Scripts/PlayerPossession.cs
@@ -491,7 +491,7 @@ public class PlayerPossession : MonoBehaviourPun {
             chatGroup.interactable = true;
             chatGroup.alpha = 1f;
             if (inputRagdolled) {
-                kobold.GetRagdoller().PopRagdoll();
+                photonView.RPC(nameof(Ragdoller.PopRagdoll), RpcTarget.All);
             }
 
             back.action.started += OnBack;
@@ -574,7 +574,7 @@ public class PlayerPossession : MonoBehaviourPun {
     // This fixes a bug where OnRagdoll isn't called when the application isn't in focus.
     void OnApplicationFocus(bool hasFocus) {
         if (hasFocus && inputRagdolled) {
-            kobold.GetRagdoller().PopRagdoll();
+            photonView.RPC(nameof(Ragdoller.PopRagdoll), RpcTarget.All);
             inputRagdolled = false;
         }
     }

--- a/Packages/com.naelstrof.inflatable/InflatableBlendshape.cs
+++ b/Packages/com.naelstrof.inflatable/InflatableBlendshape.cs
@@ -42,7 +42,9 @@ namespace Naelstrof.Inflatable {
 
         public override void OnSizeChanged(float newSize) {
             for (int i = 0; i < skinnedMeshRenderers.Count; i++) {
-                skinnedMeshRenderers[i].SetBlendShapeWeight(blendshapeIDs[i], clamped?Mathf.Clamp01(newSize)*100f : newSize*100f);
+                if (blendshapeIDs[i] != -1) {
+                    skinnedMeshRenderers[i].SetBlendShapeWeight(blendshapeIDs[i], clamped?Mathf.Clamp01(newSize)*100f : newSize*100f);
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes this issue: https://github.com/naelstrof/KoboldKare/issues/291#issue-1857353662

And the commonly known problem in modded multiplayer with different skinnedmesh equipment that'll cause crazy lag spikes when a player or npc wears "the wrong clothing".