### PR TITLE
Self penetration now only occurs when the isSelfPenetrableOnRagdoll flag is enabled on each penetrable

### DIFF
--- a/Assets/KoboldKare/NetworkedPrefabs/Kobold.prefab
+++ b/Assets/KoboldKare/NetworkedPrefabs/Kobold.prefab
@@ -1918,7 +1918,7 @@ MonoBehaviour:
     ragdollAttachBody: {fileID: 0}
     isFemaleExclusiveAnatomy: 0
     canLayEgg: 0
-    isSelfPenetrableOnRagdoll: 1
+    isSelfPenetrableOnRagdoll: 0
   attachPoints:
   - attachPoint: 0
     targetTransform: {fileID: 4363336214978915131}

--- a/Assets/KoboldKare/Scripts/Ragdoller.cs
+++ b/Assets/KoboldKare/Scripts/Ragdoller.cs
@@ -242,15 +242,13 @@ public class Ragdoller : MonoBehaviourPun, IPunObservable, ISavable, IOnPhotonVi
 
         foreach (var dickSet in kobold.activeDicks) {
             foreach (var penn in kobold.penetratables) {
-                // Legacy. Mouths are always un-ignored on ragdoll then re-added later.
-                if (penn.penetratable.name.Contains("Mouth")) {
-                    dickSet.dick.RemoveIgnorePenetrable(penn.penetratable);
-                    continue;
-                }
                 // Bool system. (Un)Ignores penetrables based on a bool inside kobold.cs
-                if (!penn.isSelfPenetrableOnRagdoll) { continue; }
-
-                dickSet.dick.RemoveIgnorePenetrable(penn.penetratable);
+                if (!penn.isSelfPenetrableOnRagdoll) {
+                    dickSet.dick.AddIgnorePenetrable(penn.penetratable);
+                }
+                else {
+                    dickSet.dick.RemoveIgnorePenetrable(penn.penetratable);
+                }
             }
         }
 
@@ -262,7 +260,6 @@ public class Ragdoller : MonoBehaviourPun, IPunObservable, ISavable, IOnPhotonVi
                     }
                 }
             }
-
             group.ForceLOD(0);
         }
 
@@ -327,11 +324,6 @@ public class Ragdoller : MonoBehaviourPun, IPunObservable, ISavable, IOnPhotonVi
             dickSet.dick.Penetrate(null);
             dickSet.dick.SetTargetHole(null);
             foreach (var penn in kobold.penetratables) {
-                // Legacy. Mouths are always un-ignored on ragdoll then re-added later.
-                if (penn.penetratable.name.Contains("Mouth")) {
-                    dickSet.dick.AddIgnorePenetrable(penn.penetratable);
-                    continue;
-                }
                 // Bool system. (Un)Ignores penetrables based on a bool inside kobold.cs
                 if (!penn.isSelfPenetrableOnRagdoll) { continue; }
                 dickSet.dick.AddIgnorePenetrable(penn.penetratable);

--- a/Packages/com.naelstrof.penetrationtech/Scripts/Penetrator.cs
+++ b/Packages/com.naelstrof.penetrationtech/Scripts/Penetrator.cs
@@ -257,7 +257,9 @@ namespace PenetrationTech {
         }
         
         public void AddIgnorePenetrable(Penetrable p) {
-            ignorePenetrables.Add(p);
+            if (!ignorePenetrables.Contains(p)) {
+                ignorePenetrables.Add(p);
+            }
         }
         public void RemoveIgnorePenetrable(Penetrable p) {
             ignorePenetrables.Remove(p);


### PR DESCRIPTION
Self penetration for Kobolds are now disabled by default.

Ensured no duplicates are added to the ignorePenetrables list.