### PR TITLE
Added different control scheme to camera

### DIFF
--- a/Assets/KoboldKare/Input/PlayerControls.inputactions
+++ b/Assets/KoboldKare/Input/PlayerControls.inputactions
@@ -265,6 +265,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "CameraOrbit",
+                    "type": "Button",
+                    "id": "afdaef1b-7eb9-41fc-aeaf-a79660be0e59",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "Press(behavior=2)",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -947,6 +956,28 @@
                     "processors": "StickDeadzone,ScaleVector2(x=40,y=40)",
                     "groups": "",
                     "action": "LookJoystick",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "187144a3-4342-4bbb-81f1-08a4dcdb8d35",
+                    "path": "<Keyboard>/leftAlt",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "CameraOrbit",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "ac0aa6ee-6951-4b8e-869c-7220952876c7",
+                    "path": "",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "CameraOrbit",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/KoboldKare/Scripts/CharacterControllerAnimator.cs
+++ b/Assets/KoboldKare/Scripts/CharacterControllerAnimator.cs
@@ -34,6 +34,7 @@ public class CharacterControllerAnimator : MonoBehaviourPun, IPunObservable, ISa
     
     public bool inputShouldFaceEye = false;
     public bool inputShouldIgnoreLookDirChange = false;
+    public bool legacyControls = false;
     private float lookModifierMemory = 0.5f;
     private float chestLookMemory = 0.5f;
     private float headLookMemory = 0.5f;
@@ -277,12 +278,19 @@ public class CharacterControllerAnimator : MonoBehaviourPun, IPunObservable, ISa
         if (!photonView.IsMine) {
             eyeRot = Vector2.MoveTowards(eyeRot, networkedEyeRot, networkedAngle * Time.deltaTime * PhotonNetwork.SerializationRate);
             facingRot = Mathf.MoveTowards(facingRot, networkedFacingRot, networkedFacingRotDiff * Time.deltaTime * PhotonNetwork.SerializationRate);
-        } else {
+        } else if (!legacyControls) {
             if (controller.inputDir != Vector3.zero && !controller.inputWalking) {
                 facingRot = Vector3.SignedAngle(controller.inputDir, Vector3.forward, Vector3.down);
             }
-            if (inputShouldFaceEye && !controller.inputWalking) {
+            else if (inputShouldFaceEye && !controller.inputWalking) {
                 facingRot = eyeRot.x;
+            }
+        } else {
+            if (!controller.inputCameraOrbiting) {
+                facingRot = eyeRot.x;
+            }
+            else if (controller.inputDir != Vector3.zero) {
+                facingRot = Vector3.SignedAngle(controller.inputDir, Vector3.forward, Vector3.down);
             }
         }
         hipVector = Vector2.SmoothDamp(hipVector, desiredHipVector, ref hipVectorVelocity, 0.05f);

--- a/Assets/KoboldKare/Scripts/KoboldCharacterController.cs
+++ b/Assets/KoboldKare/Scripts/KoboldCharacterController.cs
@@ -121,6 +121,9 @@ public class KoboldCharacterController : MonoBehaviourPun, IPunObservable, ISava
     [HideInInspector]
     public bool inputWalking = false;
 
+    [HideInInspector]
+    public bool inputCameraOrbiting = false;
+
     [Tooltip("Gravity applied per second to the character, generally to make the gravity feel less floaty.")]
     public Vector3 gravityMod = new Vector3(0, -0f, 0);
     [Tooltip("Fixed impulse for how high the character jumps.")]

--- a/Assets/KoboldKare/Scripts/PlayerPossession.cs
+++ b/Assets/KoboldKare/Scripts/PlayerPossession.cs
@@ -526,6 +526,10 @@ public class PlayerPossession : MonoBehaviourPun {
         }
     }
 
+    public void OnCameraOrbit(InputValue value) {
+        controller.inputCameraOrbiting = value.Get<float>() > 0f;
+    }
+
     IEnumerator MaintainFocus() {
         yield return new WaitForSecondsRealtime(0.1f);
         while (chatGroup.interactable && isActiveAndEnabled) {


### PR DESCRIPTION
This control scheme is more closer to the original feel of the old camera. It is entirely optional via the legacyControls flag.

The camera's direction will now (in legacy controls mode) be fixed to the character's looking-direction unless they hold the Alt-key (I have not decided on the gamepad control), then they'll be able to orbit around their character (looking around without rotating the character).

I have yet to make it an option in the settings menu. Right now it's just to see if this system is acceptable before I work any more on it.