### PR TITLE
On-spawn equipment fixes

### DIFF
--- a/Assets/KoboldKare/Scripts/CharacterDescriptor.cs
+++ b/Assets/KoboldKare/Scripts/CharacterDescriptor.cs
@@ -264,14 +264,22 @@ public class CharacterDescriptor : MonoBehaviour, IPunInstantiateMagicCallback {
     void EquipOnSpawn()
     {
         bool inMenu = SceneManager.GetActiveScene().name.Equals("MainMenu");
+        if(!inMenu && photonView && !photonView.IsMine) // Prevents joining players from forcing their equipment on others
+            return;
+                
         foreach (Equipment equip in equipOnSpawn)
         {
             Equipment newEquip;
+            if (equip == null)
+            {
+                Debug.LogError("A null equipment piece was assigned to this kobold. Please double check its character descriptor");
+                continue;
+            }
             try {
                 newEquip = EquipmentDatabase.GetEquipment(equip.name);
             } catch (UnityException exception) {
-                Debug.LogError("One or more on-spawn equipments assigned to kobold " + gameObject.name + " are invalid");
-                return;
+                Debug.LogError("One or more on-spawn equipments assigned to this kobold are invalid. Please double check its character descriptor");
+                continue;
             }
             if(!inMenu)
                 kobold.photonView.RPC(nameof(KoboldInventory.PickupEquipmentRPC), RpcTarget.All, EquipmentDatabase.GetID(newEquip), -1);


### PR DESCRIPTION
- Prevents equipment assigned on-spawn from being duplicated when a new player joins an online game
- Equipment assigned as null will be properly caught and reported by the unity debugger