### PR TITLE
Fixed issue: Player stuck in-game when kicked from room

### DIFF
--- a/Assets/KoboldKare/Scripts/NetworkManager.cs
+++ b/Assets/KoboldKare/Scripts/NetworkManager.cs
@@ -374,6 +374,11 @@ public class NetworkManager : SingletonScriptableObject<NetworkManager>, IConnec
             return;
         }
 
+        if (photonEvent.Code == 203) {
+            TriggerDisconnect();
+            return;
+        }
+
         if (photonEvent.Code != 'M') {
             return;
         }


### PR DESCRIPTION
## Issue

When masterclient kicks a player, the player's kobold will be de-spawned and lose all their in-game controls and will have to forcefully close the game. This happens because OnDisconnected() never triggers.

## Solution

OnLeftRoom() still triggers, so we only have to make sure that the player is booted back to the main menu with the reason for the disconnect. We just check if the photon event is a kick and then call the method that handles that.

I've tested it with a build and it seems to work correctly.