### PR TITLE
Dick limit increase from 255 to 65535

### DIFF
--- a/Assets/KoboldKare/Scripts/Cheats/CommandDick.cs
+++ b/Assets/KoboldKare/Scripts/Cheats/CommandDick.cs
@@ -1,10 +1,12 @@
 using System;
+using System.Collections.Generic;
 using System.Text;
 using Photon.Pun;
 
 [Serializable]
 public class CommandDick : Command {
     public override string GetArg0() => "/dick";
+
     public override void Execute(StringBuilder output, Kobold k, string[] args) {
         base.Execute(output, k, args);
         if (!CheatsProcessor.GetCheatsEnabled()) {
@@ -15,21 +17,38 @@ public class CommandDick : Command {
         }
         var infos = GameManager.GetPenisDatabase().GetValidPrefabReferenceInfos();
         // Dick setting
-        if (byte.TryParse(args[1], out byte dickID)) {
-            if (dickID != byte.MaxValue && dickID >= infos.Count) {
-                throw new CheatsProcessor.CommandException($"Index is invalid, must be either {byte.MaxValue} or under {infos.Count-1}.");
-            }
-            k.photonView.RPC(nameof(Kobold.SetDickRPC), RpcTarget.All, dickID);
-            output.AppendLine("Set dick to " + infos[dickID].GetKey() + ".");
-            return;
+        if (ushort.TryParse(args[1], out ushort dickID)) {
+            SetDickByID(output, k, infos, dickID);
         }
-        for (byte i=0;i<infos.Count;i++) {
+        else {
+            SetDickByName(output, k, infos, args);
+        }
+    }
+
+    public void SetDick(Kobold k, ushort dickID, StringBuilder output, string chatMessage) {
+        k.photonView.RPC(nameof(Kobold.SetDickRPC), RpcTarget.All, dickID);
+        output.AppendLine(chatMessage);
+    }
+
+    public void SetDickByID(StringBuilder output, Kobold k, List<PrefabDatabase.PrefabReferenceInfo> infos, ushort dickID) {
+        if (dickID != ushort.MinValue) {
+            if (dickID >= infos.Count) {
+                throw new CheatsProcessor.CommandException($"Dick ID is invalid, must be either {ushort.MinValue} or under {infos.Count - 1}.");
+            }
+            SetDick(k, dickID, output, "Set dick to " + infos[dickID - 1].GetKey() + ".");
+        }
+        else {
+            SetDick(k, dickID, output, "Set dick to None.");
+        }
+    }
+
+    public void SetDickByName(StringBuilder output, Kobold k, List<PrefabDatabase.PrefabReferenceInfo> infos, string[] args) {
+        for (ushort i = 0; i < infos.Count; i++) {
             if (infos[i].GetKey() != args[1]) continue;
-            k.photonView.RPC(nameof(Kobold.SetDickRPC), RpcTarget.All, i);
-            output.AppendLine("Set dick to " + args[1] + ".");
+            i++;
+            SetDick(k, i, output, "Set dick to " + args[1] + ".");
             return;
         }
         throw new CheatsProcessor.CommandException($"Couldn't find dick with name {args[1]}.");
     }
-
 }

--- a/Assets/KoboldKare/Scripts/Kobold.cs
+++ b/Assets/KoboldKare/Scripts/Kobold.cs
@@ -291,7 +291,7 @@ public class Kobold : GeneHolder, IGrabbable, IPunObservable, IPunInstantiateMag
             if (newGenes.dickEquip <= dickDatabase.Count) {
                 selectedDick = dickDatabase[newGenes.dickEquip - 1];
             } else {
-                Debug.LogWarning($"Couldn't find dick with id {newGenes.dickEquip - 1}, replacing with default dick.");
+                Debug.LogWarning($"Couldn't find dick with id {newGenes.dickEquip}, replacing with default dick.");
                 selectedDick = dickDatabase[0];
             }
 

--- a/Assets/KoboldKare/Scripts/Kobold.cs
+++ b/Assets/KoboldKare/Scripts/Kobold.cs
@@ -269,7 +269,7 @@ public class Kobold : GeneHolder, IGrabbable, IPunObservable, IPunInstantiateMag
     }
 
     [PunRPC]
-    public void SetDickRPC(byte dickID) {
+    public void SetDickRPC(ushort dickID) {
         SetGenes(GetGenes().With(dickEquip: dickID));
     }
 
@@ -278,20 +278,20 @@ public class Kobold : GeneHolder, IGrabbable, IPunObservable, IPunInstantiateMag
             return;
         }
         // Set dick
-        if (newGenes.dickEquip == byte.MaxValue || GetGenes() == null || newGenes.dickEquip != GetGenes().dickEquip) {
+        if (newGenes.dickEquip == ushort.MinValue || GetGenes() == null || newGenes.dickEquip != GetGenes().dickEquip) {
             if (dickObject != null) {
                 dickObject.GetComponentInChildren<DickDescriptor>().RemoveFrom(this);
                 Destroy(dickObject);
             }
         }
-        
-        if ((GetGenes() == null || newGenes.dickEquip != GetGenes().dickEquip) && newGenes.dickEquip != byte.MaxValue) {
+
+        if ((GetGenes() == null || newGenes.dickEquip != GetGenes().dickEquip) && newGenes.dickEquip != ushort.MinValue) {
             var dickDatabase = GameManager.GetPenisDatabase().GetValidPrefabReferenceInfos();
             PrefabDatabase.PrefabReferenceInfo selectedDick;
             if (newGenes.dickEquip <= dickDatabase.Count) {
-                selectedDick = dickDatabase[newGenes.dickEquip];
+                selectedDick = dickDatabase[newGenes.dickEquip - 1];
             } else {
-                Debug.LogWarning($"Couldn't find dick with id {newGenes.dickEquip}, replacing with default dick.");
+                Debug.LogWarning($"Couldn't find dick with id {newGenes.dickEquip - 1}, replacing with default dick.");
                 selectedDick = dickDatabase[0];
             }
 

--- a/Assets/KoboldKare/Scripts/Kobold.cs
+++ b/Assets/KoboldKare/Scripts/Kobold.cs
@@ -277,7 +277,10 @@ public class Kobold : GeneHolder, IGrabbable, IPunObservable, IPunInstantiateMag
         if (newGenes == null) {
             return;
         }
-        // Set dick
+
+        // Removing the dick is now 0 instead of 255.
+        // Dick IDs start at 1, but internally will remain starting at 0.
+        // i.e. Getting the first dick from the dick database will be dickDatabase[dickID - 1].
         if (newGenes.dickEquip == ushort.MinValue || GetGenes() == null || newGenes.dickEquip != GetGenes().dickEquip) {
             if (dickObject != null) {
                 dickObject.GetComponentInChildren<DickDescriptor>().RemoveFrom(this);

--- a/Assets/KoboldKare/Scripts/KoboldGenes.cs
+++ b/Assets/KoboldKare/Scripts/KoboldGenes.cs
@@ -35,7 +35,7 @@ public static class KoboldGenesBitBufferExtension {
         buffer.AddByte(genes.hue);
         buffer.AddByte(genes.brightness);
         buffer.AddByte(genes.saturation);
-        buffer.AddByte(genes.dickEquip);
+        buffer.AddUShort(genes.dickEquip);
         buffer.AddByte(genes.grabCount);
         buffer.AddByte(genes.species);
     }
@@ -56,7 +56,7 @@ public static class KoboldGenesBitBufferExtension {
             hue = buffer.ReadByte(),
             brightness = buffer.ReadByte(),
             saturation = buffer.ReadByte(),
-            dickEquip = buffer.ReadByte(),
+            dickEquip = buffer.ReadUShort(),
             grabCount = buffer.ReadByte(),
             species = buffer.ReadByte()
         };
@@ -77,7 +77,7 @@ public class KoboldGenes {
     public byte hue;
     public byte brightness = 128;
     public byte saturation = 128;
-    public byte dickEquip = byte.MaxValue;
+    public ushort dickEquip = ushort.MinValue;
     public byte grabCount = 1;
     public byte species = 0;
 
@@ -108,7 +108,7 @@ public class KoboldGenes {
     public KoboldGenes With(float? maxEnergy = null, float? baseSize = null, float? fatSize = null,
             float? ballSize = null, float? dickSize = null, float? breastSize = null, float? bellySize = null,
             float? metabolizeCapacitySize = null, byte? hue = null, byte? brightness = null,
-            byte? saturation = null, byte? dickEquip = null, float? dickThickness = null, byte? grabCount = null, byte? species = null) {
+            byte? saturation = null, ushort? dickEquip = null, float? dickThickness = null, byte? grabCount = null, byte? species = null) {
         return new KoboldGenes() {
             maxEnergy = maxEnergy ?? this.maxEnergy,
             baseSize = baseSize ?? this.baseSize,
@@ -128,26 +128,26 @@ public class KoboldGenes {
         };
     }
 
-    private byte GetRandomDick() {
+    private ushort GetRandomDick() {
         var penisDatabase = GameManager.GetPenisDatabase();
         var penises = penisDatabase.GetValidPrefabReferenceInfos();
         var selectedPenis = penisDatabase.GetRandom();
         if (selectedPenis == null) {
             throw new UnityException("Failed to get a penis, penis database is probably empty.");
         }
-        return (byte)penises.IndexOf(selectedPenis);
+        return (ushort)penises.IndexOf(selectedPenis);
     }
-    private byte GetDickIndex(string name){
+    private ushort GetDickIndex(string name){
         var penisDatabase = GameManager.GetPenisDatabase();
         var dicks = penisDatabase.GetValidPrefabReferenceInfos();
         foreach (var info in dicks) {
             if (name.Contains(info.GetKey())) {
-                return (byte)dicks.IndexOf(info);
+                return (ushort)dicks.IndexOf(info);
             }
         }
         return GetRandomDick();// Get random dick if can't find the correct one
     }
-    private string GetDickName(byte id){
+    private string GetDickName(ushort id){
         var penisDatabase = GameManager.GetPenisDatabase();
         var dicks = penisDatabase.GetValidPrefabReferenceInfos();
         return dicks[id].GetKey();
@@ -176,7 +176,7 @@ public class KoboldGenes {
             dickEquip = GetRandomDick();
         } else {
             breastSize = (float)NextGaussian(15f*meanMultiplier,5.5f*standardDeviationMultiplier,0f, float.MaxValue);
-            dickEquip = byte.MaxValue;
+            dickEquip = ushort.MinValue;
         }
 
         ballSize = (float)NextGaussian(10f*meanMultiplier,5.5f*standardDeviationMultiplier,5f, float.MaxValue);
@@ -299,7 +299,7 @@ public class KoboldGenes {
         rootNode["hue"] = (int)hue;
         rootNode["brightness"] = (int)brightness;
         rootNode["saturation"] = (int)saturation;
-        rootNode["dickEquip"] = dickEquip==byte.MaxValue?"None":GetDickName(dickEquip);
+        rootNode["dickEquip"] = dickEquip==ushort.MaxValue?"None":GetDickName(dickEquip);
         rootNode["grabCount"] = (int)grabCount;
         rootNode["dickThickness"] = dickThickness;
         rootNode["species"] = GetPlayerName(species);
@@ -319,7 +319,7 @@ public class KoboldGenes {
         hue = (byte)rootNode["hue"].AsInt;
         brightness = (byte)rootNode["brightness"].AsInt;
         saturation = (byte)rootNode["saturation"].AsInt;
-        dickEquip = rootNode["dickEquip"]=="None"? byte.MaxValue: (byte)GetDickIndex(rootNode["dickEquip"]);
+        dickEquip = rootNode["dickEquip"]=="None"? ushort.MaxValue: (ushort)GetDickIndex(rootNode["dickEquip"]);
         grabCount = (byte)rootNode["grabCount"].AsInt;
         species = (byte)GetPlayerIndex(rootNode["species"]);
         dickThickness = rootNode["dickThickness"];

--- a/Assets/KoboldKare/Scripts/PlayerKoboldLoader.cs
+++ b/Assets/KoboldKare/Scripts/PlayerKoboldLoader.cs
@@ -48,9 +48,9 @@ public class PlayerKoboldLoader : MonoBehaviour {
                 var validInfos = database.GetValidPrefabReferenceInfos();
                 var info = database.GetInfoByName("HumanoidDick");
                 if (info == null) {
-                    genes.dickEquip = (setting.GetValue() == 0f) ? byte.MaxValue : (byte)0;
+                    genes.dickEquip = (setting.GetValue() == 0f) ? ushort.MinValue : (ushort)1;
                 } else {
-                    genes.dickEquip = (setting.GetValue() == 0f) ? byte.MaxValue : (byte)validInfos.IndexOf(info);
+                    genes.dickEquip = (setting.GetValue() == 0f) ? ushort.MinValue : (ushort)(validInfos.IndexOf(info) + 1);
                 }
 
                 break;


### PR DESCRIPTION
Up until now dick type selection has using the `byte` data type, limiting it to 255 different dicks. Workshop mods are steadily increasing the number of dicks in-game, making this limit reachable in the foreseeable future.

I have now changed all the relevant units of code (that I know of) that use this data type to `ushort` in relation to the dick database and selection.

I have changed the dick ID for removal of the dick to be 0 instead of its type's max value since it's easier to remember and more intuitive. Furthermore, I have refactored a bit of the CommandDick class to make it a bit more obvious what is going on.

Let me know if any changes should be made for acceptance or anything I might've missed.