### PR TITLE
Photon does not like unsigned value types

### DIFF
--- a/Assets/KoboldKare/Scripts/Cheats/CommandDick.cs
+++ b/Assets/KoboldKare/Scripts/Cheats/CommandDick.cs
@@ -17,22 +17,22 @@ public class CommandDick : Command {
         }
         var infos = GameManager.GetPenisDatabase().GetValidPrefabReferenceInfos();
         // Dick setting
-        if (ushort.TryParse(args[1], out ushort dickID)) {
+        if (short.TryParse(args[1], out short dickID)) {
             SetDickByID(output, k, infos, dickID);
         } else {
             SetDickByName(output, k, infos, args);
         }
     }
 
-    private void SetDick(Kobold k, ushort dickID, StringBuilder output, string chatMessage) {
+    private void SetDick(Kobold k, short dickID, StringBuilder output, string chatMessage) {
         k.photonView.RPC(nameof(Kobold.SetDickRPC), RpcTarget.All, dickID);
         output.AppendLine(chatMessage);
     }
 
-    private void SetDickByID(StringBuilder output, Kobold k, List<PrefabDatabase.PrefabReferenceInfo> infos, ushort dickID) {
-        if (dickID != ushort.MinValue) {
+    private void SetDickByID(StringBuilder output, Kobold k, List<PrefabDatabase.PrefabReferenceInfo> infos, short dickID) {
+        if (dickID != short.MinValue) {
             if (dickID >= infos.Count) {
-                throw new CheatsProcessor.CommandException($"Dick ID is invalid, must be either {ushort.MinValue} or under {infos.Count - 1}.");
+                throw new CheatsProcessor.CommandException($"Dick ID is invalid, must be either {short.MinValue} or under {infos.Count - 1}.");
             }
             SetDick(k, dickID, output, "Set dick to " + infos[dickID - 1].GetKey() + ".");
         } else {
@@ -41,7 +41,7 @@ public class CommandDick : Command {
     }
 
     private void SetDickByName(StringBuilder output, Kobold k, List<PrefabDatabase.PrefabReferenceInfo> infos, string[] args) {
-        for (ushort i = 0; i < infos.Count; i++) {
+        for (short i = 0; i < infos.Count; i++) {
             if (infos[i].GetKey() != args[1]) continue;
             i++;
             SetDick(k, i, output, "Set dick to " + args[1] + ".");

--- a/Assets/KoboldKare/Scripts/Kobold.cs
+++ b/Assets/KoboldKare/Scripts/Kobold.cs
@@ -269,7 +269,7 @@ public class Kobold : GeneHolder, IGrabbable, IPunObservable, IPunInstantiateMag
     }
 
     [PunRPC]
-    public void SetDickRPC(ushort dickID) {
+    public void SetDickRPC(short dickID) {
         SetGenes(GetGenes().With(dickEquip: dickID));
     }
 
@@ -281,14 +281,14 @@ public class Kobold : GeneHolder, IGrabbable, IPunObservable, IPunInstantiateMag
         // Removing the dick is now 0 instead of 255.
         // Dick IDs start at 1, but internally will remain starting at 0.
         // i.e. Getting the first dick from the dick database will be dickDatabase[dickID - 1].
-        if (newGenes.dickEquip == ushort.MinValue || GetGenes() == null || newGenes.dickEquip != GetGenes().dickEquip) {
+        if (newGenes.dickEquip == short.MinValue || GetGenes() == null || newGenes.dickEquip != GetGenes().dickEquip) {
             if (dickObject != null) {
                 dickObject.GetComponentInChildren<DickDescriptor>().RemoveFrom(this);
                 Destroy(dickObject);
             }
         }
 
-        if ((GetGenes() == null || newGenes.dickEquip != GetGenes().dickEquip) && newGenes.dickEquip != ushort.MinValue) {
+        if ((GetGenes() == null || newGenes.dickEquip != GetGenes().dickEquip) && newGenes.dickEquip != short.MinValue) {
             var dickDatabase = GameManager.GetPenisDatabase().GetValidPrefabReferenceInfos();
             PrefabDatabase.PrefabReferenceInfo selectedDick;
             if (newGenes.dickEquip <= dickDatabase.Count) {

--- a/Assets/KoboldKare/Scripts/KoboldGenes.cs
+++ b/Assets/KoboldKare/Scripts/KoboldGenes.cs
@@ -35,7 +35,7 @@ public static class KoboldGenesBitBufferExtension {
         buffer.AddByte(genes.hue);
         buffer.AddByte(genes.brightness);
         buffer.AddByte(genes.saturation);
-        buffer.AddUShort(genes.dickEquip);
+        buffer.AddShort(genes.dickEquip);
         buffer.AddByte(genes.grabCount);
         buffer.AddByte(genes.species);
     }
@@ -56,7 +56,7 @@ public static class KoboldGenesBitBufferExtension {
             hue = buffer.ReadByte(),
             brightness = buffer.ReadByte(),
             saturation = buffer.ReadByte(),
-            dickEquip = buffer.ReadUShort(),
+            dickEquip = buffer.ReadShort(),
             grabCount = buffer.ReadByte(),
             species = buffer.ReadByte()
         };
@@ -77,7 +77,7 @@ public class KoboldGenes {
     public byte hue;
     public byte brightness = 128;
     public byte saturation = 128;
-    public ushort dickEquip = ushort.MinValue;
+    public short dickEquip = short.MinValue;
     public byte grabCount = 1;
     public byte species = 0;
 
@@ -108,7 +108,7 @@ public class KoboldGenes {
     public KoboldGenes With(float? maxEnergy = null, float? baseSize = null, float? fatSize = null,
             float? ballSize = null, float? dickSize = null, float? breastSize = null, float? bellySize = null,
             float? metabolizeCapacitySize = null, byte? hue = null, byte? brightness = null,
-            byte? saturation = null, ushort? dickEquip = null, float? dickThickness = null, byte? grabCount = null, byte? species = null) {
+            byte? saturation = null, short? dickEquip = null, float? dickThickness = null, byte? grabCount = null, byte? species = null) {
         return new KoboldGenes() {
             maxEnergy = maxEnergy ?? this.maxEnergy,
             baseSize = baseSize ?? this.baseSize,
@@ -128,25 +128,25 @@ public class KoboldGenes {
         };
     }
 
-    private ushort GetRandomDick() {
+    private short GetRandomDick() {
         var penisDatabase = GameManager.GetPenisDatabase();
         var penises = penisDatabase.GetValidPrefabReferenceInfos();
         if (!penisDatabase.TryGetRandom(out var selectedPenis)) {
             throw new UnityException("Failed to get a penis, penis database is probably empty.");
         }
-        return (ushort)penises.IndexOf(selectedPenis);
+        return (short)penises.IndexOf(selectedPenis);
     }
-    private ushort GetDickIndex(string name){
+    private short GetDickIndex(string name){
         var penisDatabase = GameManager.GetPenisDatabase();
         var dicks = penisDatabase.GetValidPrefabReferenceInfos();
         foreach (var info in dicks) {
             if (name.Contains(info.GetKey())) {
-                return (ushort)dicks.IndexOf(info);
+                return (short)dicks.IndexOf(info);
             }
         }
         return GetRandomDick();// Get random dick if can't find the correct one
     }
-    private string GetDickName(ushort id){
+    private string GetDickName(short id){
         var penisDatabase = GameManager.GetPenisDatabase();
         var dicks = penisDatabase.GetValidPrefabReferenceInfos();
         return dicks[id].GetKey();
@@ -175,7 +175,7 @@ public class KoboldGenes {
             dickEquip = GetRandomDick();
         } else {
             breastSize = (float)NextGaussian(15f*meanMultiplier,5.5f*standardDeviationMultiplier,0f, float.MaxValue);
-            dickEquip = ushort.MinValue;
+            dickEquip = short.MinValue;
         }
 
         ballSize = (float)NextGaussian(10f*meanMultiplier,5.5f*standardDeviationMultiplier,5f, float.MaxValue);
@@ -298,7 +298,7 @@ public class KoboldGenes {
         rootNode["hue"] = (int)hue;
         rootNode["brightness"] = (int)brightness;
         rootNode["saturation"] = (int)saturation;
-        rootNode["dickEquip"] = dickEquip==ushort.MaxValue?"None":GetDickName(dickEquip);
+        rootNode["dickEquip"] = dickEquip==short.MaxValue?"None":GetDickName(dickEquip);
         rootNode["grabCount"] = (int)grabCount;
         rootNode["dickThickness"] = dickThickness;
         rootNode["species"] = GetPlayerName(species);
@@ -318,7 +318,7 @@ public class KoboldGenes {
         hue = (byte)rootNode["hue"].AsInt;
         brightness = (byte)rootNode["brightness"].AsInt;
         saturation = (byte)rootNode["saturation"].AsInt;
-        dickEquip = rootNode["dickEquip"]=="None"? ushort.MaxValue: (ushort)GetDickIndex(rootNode["dickEquip"]);
+        dickEquip = rootNode["dickEquip"]=="None"? short.MaxValue: (short)GetDickIndex(rootNode["dickEquip"]);
         grabCount = (byte)rootNode["grabCount"].AsInt;
         species = (byte)GetPlayerIndex(rootNode["species"]);
         dickThickness = rootNode["dickThickness"];

--- a/Assets/KoboldKare/Scripts/PlayerKoboldLoader.cs
+++ b/Assets/KoboldKare/Scripts/PlayerKoboldLoader.cs
@@ -48,9 +48,9 @@ public class PlayerKoboldLoader : MonoBehaviour {
                 var validInfos = database.GetValidPrefabReferenceInfos();
                 var info = database.GetInfoByName("HumanoidDick");
                 if (info == null) {
-                    genes.dickEquip = (setting.GetValue() == 0f) ? ushort.MinValue : (ushort)1;
+                    genes.dickEquip = (setting.GetValue() == 0f) ? short.MinValue : (short)1;
                 } else {
-                    genes.dickEquip = (setting.GetValue() == 0f) ? ushort.MinValue : (ushort)(validInfos.IndexOf(info) + 1);
+                    genes.dickEquip = (setting.GetValue() == 0f) ? short.MinValue : (short)(validInfos.IndexOf(info) + 1);
                 }
 
                 break;


### PR DESCRIPTION
Changed all the ushort types to short from this PR https://github.com/naelstrof/KoboldKare/pull/370 since photon freaks out over it not being a registered custom type when it's used in `CommandDick.SetDick`. It'll half the amount down to 32767, not that we'll ever reach that many dick types anyway. :p