### PR TITLE
Expanded GameEventResponse

### DIFF
--- a/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseAnimatorIntChange.cs
+++ b/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseAnimatorIntChange.cs
@@ -1,0 +1,24 @@
+using System;
+using UnityEngine;
+
+[System.Serializable]
+public class GameEventResponseAnimatorIntChange : GameEventResponse
+{
+    [Serializable]
+    private class AnimatorIntTarget
+    {
+        [SerializeField] public Animator animator;
+        [SerializeField] public string intName;
+        [SerializeField] public int intValue;
+    }
+
+    [SerializeField] private AnimatorIntTarget[] targets;
+
+    public override void Invoke(MonoBehaviour owner)
+    {
+        base.Invoke(owner);
+        foreach (var target in targets) {
+            target.animator.SetInteger(target.intName, target.intValue);
+        }
+    }
+}

--- a/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseAnimatorIntChange.cs.meta
+++ b/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseAnimatorIntChange.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a577b107dd1e9da588e810ef2988f242
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseBucketFireComplete.cs
+++ b/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseBucketFireComplete.cs
@@ -1,0 +1,21 @@
+using System;
+using UnityEngine;
+
+[System.Serializable]
+public class GameEventResponseBucketFireComplete : GameEventResponse
+{
+    [Serializable]
+    private class BucketFireTarget
+    {
+        [SerializeField] public BucketWeapon Bucket;
+    }
+
+    [SerializeField] private BucketFireTarget[] targets;
+
+    public override void Invoke(MonoBehaviour owner){
+        base.Invoke(owner);
+        foreach (var target in targets) {
+            target.Bucket.OnFireComplete();
+        }
+    }
+}

--- a/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseBucketFireComplete.cs.meta
+++ b/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseBucketFireComplete.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: dfa2791a04a40050faf878dd98dfdc43
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseButtonUse.cs
+++ b/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseButtonUse.cs
@@ -1,0 +1,21 @@
+using System;
+using UnityEngine;
+
+[System.Serializable]
+public class GameEventResponseButtonUse : GameEventResponse
+{
+    [Serializable]
+    private class ButtonUseTarget
+    {
+        [SerializeField] public ButtonUsable Button;
+    }
+
+    [SerializeField] private ButtonUseTarget[] targets;
+
+    public override void Invoke(MonoBehaviour owner){
+        base.Invoke(owner);
+        foreach (var target in targets) {
+            target.Button.Use();
+        }
+    }
+}

--- a/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseButtonUse.cs.meta
+++ b/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseButtonUse.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3f3f9ef5a03f8320d924ba562d89ef6d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseConstructedSet.cs
+++ b/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseConstructedSet.cs
@@ -1,0 +1,20 @@
+using System;
+using UnityEngine;
+
+[System.Serializable]
+public class GameEventResponseConstructedSet : GameEventResponse
+{
+    [Serializable] public class ConstructedSetTarget
+    {
+        [SerializeField] public UsableMachine targetMachine;
+        [SerializeField] public bool beConstructed;
+    }
+
+    [SerializeField] private ConstructedSetTarget[] targets;
+    public override void Invoke(MonoBehaviour owner) {
+        base.Invoke(owner);
+        foreach (var target in targets) {
+            target.targetMachine.SetConstructed(target.beConstructed);
+        }
+    }
+}

--- a/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseConstructedSet.cs.meta
+++ b/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseConstructedSet.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 3bab0f436beb17f02943d71d60a19c76
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseParticleSystemPlay.cs
+++ b/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseParticleSystemPlay.cs
@@ -1,0 +1,26 @@
+using System;
+using UnityEngine;
+using UnityEngine.VFX;
+
+[System.Serializable]
+public class GameEventResponseParticleSystemPlay : GameEventResponse
+{
+    [Serializable]
+    private class ParticleSystemTarget
+    {
+        [SerializeField] public VisualEffect VFX;
+        [SerializeField] public String possibleEventName;
+    }
+
+    [SerializeField] private ParticleSystemTarget[] targets;
+
+    public override void Invoke(MonoBehaviour owner){
+        base.Invoke(owner);
+        foreach (var target in targets) {
+            target.VFX.Play();
+            if (target.possibleEventName != null) {
+            target.VFX.SendEvent(target.possibleEventName);
+            }
+        }
+    }
+}

--- a/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseParticleSystemPlay.cs.meta
+++ b/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseParticleSystemPlay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1aa9d6dc595bbb5cc9e2712690037a75
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adds:
- AnimatorIntChange - Similar to AnimatorBoolToggle, but for Integers.
- BucketFireComplete - Calls the FireComplete() method on selected Bucket Weapons.
- ButtonUse - Calls the Use() method on selected Button Usables.
- ParticleSystemPlay - Calls Play() on selected Particle Systems, then, if set, calls SendEvent of a possibleEventName, latter is skipped if possibleEventName is not set.
- Constructed Set - Calls SetConstructed(beConstructed) on selected Usable Machines, the beConstructed bool is tied to each target Usable Machine, enabling you to construct and deconstruct Machines with a single Constructed Set Response.