### PR TITLE
Expand Game Responses 2

### DIFF
--- a/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseAnimatorMathInteger.cs
+++ b/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseAnimatorMathInteger.cs
@@ -1,0 +1,26 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.CompilerServices;
+using UnityEngine;
+
+[Serializable]
+public class GameEventResponseAnimatorMathInteger : GameEventResponse
+{
+    [Serializable]
+    private struct AnimatorIntTarget
+    {
+        [SerializeField] public Animator animator;
+        [SerializeField] public string intName;
+        [SerializeField] public int Value;
+    }
+
+    [SerializeField] private AnimatorIntTarget[] targets;
+    public override void Invoke(MonoBehaviour owner)
+    {
+        base.Invoke(owner);
+        foreach (var target in targets) {
+            var currentValue = target.animator.GetInteger(target.intName);
+                target.animator.SetInteger(target.intName, currentValue + target.Value);
+        }
+    }
+}

--- a/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseConditionalAnimatorInt.cs
+++ b/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseConditionalAnimatorInt.cs
@@ -1,0 +1,121 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[Serializable]
+public class GameEventResponseConditionalAnimatorInt : GameEventResponse
+{
+    [SerializeField] public Animator animator;
+    [SerializeField] public string parameterName;
+    [SerializeField] public int targetInteger;
+    [SerializeField, Range(0, 5), Tooltip("0 is =, 1 is ≠, 2 is <, 3 is >, 4 is ≤, 5 is ≥")] public int Operator;
+    [SerializeField, SubclassSelector, SerializeReference] private List<GameEventResponse> requirementMet = new List<GameEventResponse>();
+    [SerializeField, SubclassSelector, SerializeReference] private List<GameEventResponse> requirementFailed = new List<GameEventResponse>();
+
+
+    public override void Invoke(MonoBehaviour owner)
+    {
+        int aniParamator = animator.GetInteger(parameterName);
+
+        switch (Operator)
+        {
+            case 0:
+                if (aniParamator == targetInteger)
+                {
+                    foreach (var response in requirementMet)
+                    {
+                        response?.Invoke(owner);
+                    }
+                }
+                else
+                {
+                    foreach (var response in requirementFailed)
+                    {
+                        response?.Invoke(owner);
+                    }
+                }
+                break;
+            case 1:
+                if (aniParamator != targetInteger)
+                {
+                    foreach (var response in requirementMet)
+                    {
+                        response?.Invoke(owner);
+                    }
+                }
+                else
+                {
+                    foreach (var response in requirementFailed)
+                    {
+                        response?.Invoke(owner);
+                    }
+                }
+                break;
+            case 2:
+                if (aniParamator < targetInteger)
+                {
+                    foreach (var response in requirementMet)
+                    {
+                        response?.Invoke(owner);
+                    }
+                }
+                else
+                {
+                    foreach (var response in requirementFailed)
+                    {
+                        response?.Invoke(owner);
+                    }
+                }
+                break;
+            case 3:
+                if (aniParamator > targetInteger)
+                {
+                    foreach (var response in requirementMet)
+                    {
+                        response?.Invoke(owner);
+                    }
+                }
+                else
+                {
+                    foreach (var response in requirementFailed)
+                    {
+                        response?.Invoke(owner);
+                    }
+                }
+                break;
+            case 4:
+                if (aniParamator <= targetInteger)
+                {
+                    foreach (var response in requirementMet)
+                    {
+                        response?.Invoke(owner);
+                    }
+                }
+                else
+                {
+                    foreach (var response in requirementFailed)
+                    {
+                        response?.Invoke(owner);
+                    }
+                }
+                break;
+            case 5:
+                if (aniParamator >= targetInteger)
+                {
+                    foreach (var response in requirementMet)
+                    {
+                        response?.Invoke(owner);
+                    }
+                }
+                else
+                {
+                    foreach (var response in requirementFailed)
+                    {
+                        response?.Invoke(owner);
+                    }
+                }
+                break;
+        }
+    }
+}

--- a/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseConditionalCountEnabled.cs
+++ b/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseConditionalCountEnabled.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[Serializable]
+public class GameEventResponseConditionalCountEnabled : GameEventResponse
+{
+    [SerializeField] public GameObject[] trackedObjects;
+    [SerializeField, MinAttribute(0)] public int Requirement;
+    [SerializeField] public bool trackDisabledInstead;
+    [SerializeField, SubclassSelector, SerializeReference] private List<GameEventResponse> requirementMet = new List<GameEventResponse>();
+    [SerializeField, SubclassSelector, SerializeReference] private List<GameEventResponse> requirementFailed = new List<GameEventResponse>();
+    private int enabledCount = 0;
+
+
+    public override void Invoke(MonoBehaviour owner)
+    {
+        enabledCount = 0;
+        foreach (var target in trackedObjects)
+        {
+            if (target.activeSelf)
+            {
+                enabledCount++;
+            }
+        }
+
+
+        if (!trackDisabledInstead)
+        {
+            if (enabledCount >= Requirement)
+            {
+                foreach (var response in requirementMet)
+                {
+                    response?.Invoke(owner);
+                }
+            } else
+            {
+               foreach (var response in requirementFailed)
+                {
+                    response?.Invoke(owner);
+                } 
+            }
+        } else
+        {
+            if (enabledCount <= Requirement)
+            {
+                foreach (var response in requirementMet)
+                {
+                    response?.Invoke(owner);
+                }
+            } else
+            {
+               foreach (var response in requirementFailed)
+                {
+                    response?.Invoke(owner);
+                } 
+            }
+        }
+    }
+}

--- a/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseConditionalRandom.cs
+++ b/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseConditionalRandom.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+[Serializable]
+public class GameEventResponseConditionalRandom : GameEventResponse
+{
+    public int Min;
+    public int Max;
+    public int MininumRequirement;
+    [SerializeField, SubclassSelector, SerializeReference] private List<GameEventResponse> requirementMet = new List<GameEventResponse>();
+    private int Roll;
+
+    public override void Invoke(MonoBehaviour owner)
+    {
+        Roll = UnityEngine.Random.Range(Min, Max);
+        if (Roll >= MininumRequirement)
+        {
+            foreach (var response in requirementMet)
+            {
+                response?.Invoke(owner);
+            }
+        }
+    }
+}


### PR DESCRIPTION
### A refork of #390, made cleaner by putting everything into it's own branch. Now 100000% less of a headache to maintain and a 0% chance of effectively undoing PRs by merging PRs in the wrong order.

## Explanations (from the old PR):
- AnimatorMathInteger - Similar to AnimatorSetInteger, but adds the specified Value to the currentValue of the specified Integer.
  - Value can be negative, instead Subtracting from the currentValue.

- ConditionalCountEnabled - Counts the number of enabled trackedObjects, then invokes two different Response sets, dependent on whether or not the total enabledCount is **greater than or equal to** the Requirement.
  - Can be inverted to instead track disabled objects, instead passing the Requirement if enabledCount is **lesser than or equal to** the Requirement.

- ConditionalAnimatorInt - Gets the defined **AniParameter** from **Animator** using **ParameterName**, and checks to see if it passes **TargetInteger** against the selected **Operator**.
  - Operator is defined via **slider with range from 0 to 5**, default is **0 (==)**
  - Runs Responses **depending on Pass/Fail**, similar to ConditionalEnabledCount.

- ConditionalRandom
  - Rolls a _random number_ between **Min** and **Max**, if the **Roll** is _greater than or equal to_ the **Minimum Requirement**, invokes Responses.