### PR TITLE
Make Gravity Manipulatable (Reforked)

### DIFF
--- a/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseGravityChange.cs
+++ b/Assets/KoboldKare/Scripts/GameEvents/GameEventResponseGravityChange.cs
@@ -1,0 +1,15 @@
+using System;
+using UnityEngine;
+
+[Serializable]
+public class GameEventResponseGravityChange : GameEventResponse
+{
+    public Vector3 Gravity = new(0f,-9.81f,0f);
+
+
+    public override void Invoke(MonoBehaviour owner)
+    {
+        Physics.gravity = Gravity;
+        Physics.clothGravity = Gravity;
+    }
+}

--- a/Assets/KoboldKare/Scripts/GravityManipulator.cs
+++ b/Assets/KoboldKare/Scripts/GravityManipulator.cs
@@ -1,0 +1,14 @@
+using System;
+using UnityEngine;
+
+public class GravityManipulator : MonoBehaviour
+{
+    [Range(-200f, 0f)]
+    public float Gravity = -9.81f;
+    private void Start()
+    {
+
+        Physics.gravity = new(0f, Gravity, 0f);
+        Physics.clothGravity = new(0f, Gravity, 0f);
+    }
+}

--- a/Assets/KoboldKare/Scripts/KoboldCharacterController.cs
+++ b/Assets/KoboldKare/Scripts/KoboldCharacterController.cs
@@ -6,6 +6,7 @@ using Photon.Realtime;
 using ExitGames.Client.Photon;
 using System.IO;
 using SimpleJSON;
+using Unity.Mathematics;
 
 [RequireComponent(typeof(Rigidbody))]
 public class KoboldCharacterController : MonoBehaviourPun, IPunObservable, ISavable {
@@ -251,7 +252,7 @@ public class KoboldCharacterController : MonoBehaviourPun, IPunObservable, ISava
         float radius = groundCheckRadius * transform.lossyScale.x;
         for(float x = -radius; x <= radius; x+=radius) {
             for (float y = -radius; y <= radius; y += radius) {
-                if (Physics.Raycast(collider.transform.TransformPoint(collider.center) + new Vector3(x,0,y), Vector3.down, out hit, 5f*transform.lossyScale.x, GameManager.instance.walkableGroundMask)) {
+                if (Physics.Raycast(collider.transform.TransformPoint(collider.center) + new Vector3(x,0,y), Physics.gravity, out hit, 5f*transform.lossyScale.x, GameManager.instance.walkableGroundMask)) {
                     floorNormal = hit.normal;
                     distanceToGround = hit.distance;
                     if (hit.normal.y >= 0.7f && hit.distance <= effectiveStepCheckDistance + 0.05f) {
@@ -346,6 +347,7 @@ public class KoboldCharacterController : MonoBehaviourPun, IPunObservable, ISava
         if (photonView.IsMine || !PhotonNetwork.InRoom) {
             body.velocity = velocity;
         }
+        body.transform.rotation = Quaternion.FromToRotation(body.transform.up, -Physics.gravity) * body.transform.rotation;
     }
 
     private void JumpCheck() {


### PR DESCRIPTION
## A refork of #396, no longer strapped with explosives triggered to explode and delete the Responses PR if merged after

Adds **GravityManipulator** and **GameEventResponseGravityChange**.
- Gravity Manipulator **sets the gravity on map start**, recommended to include in **ObjectiveManager**. If not included, Unity would use the gravity set in Project Settings.
- Gravity Change changes the gravity by the **set Vector3**, can be used to change the gravity of the map **on a trigger**.

TODO:
- [ ] Make grounded collision work with all directions of gravity
- [ ] (Possibly) Rework the gravity system to use gravity fields that apply force rather than a global gravity force. Enabling Super Mario Galaxy-like gravity.