### PR TITLE
Assorted QoL

### DIFF
--- a/Assets/KoboldKare/Prefabs/GameManager.prefab
+++ b/Assets/KoboldKare/Prefabs/GameManager.prefab
@@ -24396,8 +24396,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dbcb31de5617996449b00a4330cc41ae, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  controls: {fileID: -944628639613478452, guid: b80237a58ac8c22458251d7c9dcacf88,
-    type: 3}
 --- !u!114 &8298682615481124282
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -24452,6 +24450,7 @@ MonoBehaviour:
   - rid: 1602997817464061955
   - rid: 991488056044552193
   - rid: 991488175422570496
+  - rid: 3900068453231886386
   references:
     version: 2
     RefIds:
@@ -24503,6 +24502,22 @@ MonoBehaviour:
           m_FallbackState: 0
           m_WaitForCompletion: 0
           m_LocalVariables: []
+    - rid: 3900068453231886386
+      type: {class: CommandClone, ns: , asm: Assembly-CSharp}
+      data:
+        description:
+          m_TableReference:
+            m_TableCollectionName: 
+          m_TableEntryReference:
+            m_KeyId: 0
+            m_Key: 
+          m_FallbackState: 0
+          m_WaitForCompletion: 0
+          m_LocalVariables: []
+        koboldPrefab:
+          gameObject: {fileID: 8587189159933912498, guid: c03e2c2295efd074c8f62bae057e84ae,
+            type: 3}
+          optionalDatabase: {fileID: 0}
     - rid: 8920608363450728448
       type: {class: CommandHelp, ns: , asm: Assembly-CSharp}
       data:

--- a/Assets/KoboldKare/Prefabs/GameManager.prefab
+++ b/Assets/KoboldKare/Prefabs/GameManager.prefab
@@ -24451,6 +24451,7 @@ MonoBehaviour:
   - rid: 991488056044552193
   - rid: 991488175422570496
   - rid: 3900068453231886386
+  - rid: 3900068453231886396
   references:
     version: 2
     RefIds:
@@ -24518,6 +24519,18 @@ MonoBehaviour:
           gameObject: {fileID: 8587189159933912498, guid: c03e2c2295efd074c8f62bae057e84ae,
             type: 3}
           optionalDatabase: {fileID: 0}
+    - rid: 3900068453231886396
+      type: {class: CommandFlush, ns: , asm: Assembly-CSharp}
+      data:
+        description:
+          m_TableReference:
+            m_TableCollectionName: 
+          m_TableEntryReference:
+            m_KeyId: 0
+            m_Key: 
+          m_FallbackState: 0
+          m_WaitForCompletion: 0
+          m_LocalVariables: []
     - rid: 8920608363450728448
       type: {class: CommandHelp, ns: , asm: Assembly-CSharp}
       data:

--- a/Assets/KoboldKare/Prefabs/GameManager.prefab
+++ b/Assets/KoboldKare/Prefabs/GameManager.prefab
@@ -24452,6 +24452,7 @@ MonoBehaviour:
   - rid: 991488175422570496
   - rid: 3900068453231886386
   - rid: 3900068453231886396
+  - rid: 7739000595272171520
   references:
     version: 2
     RefIds:
@@ -24521,6 +24522,18 @@ MonoBehaviour:
           optionalDatabase: {fileID: 0}
     - rid: 3900068453231886396
       type: {class: CommandFlush, ns: , asm: Assembly-CSharp}
+      data:
+        description:
+          m_TableReference:
+            m_TableCollectionName: 
+          m_TableEntryReference:
+            m_KeyId: 0
+            m_Key: 
+          m_FallbackState: 0
+          m_WaitForCompletion: 0
+          m_LocalVariables: []
+    - rid: 7739000595272171520
+      type: {class: CommandView, ns: , asm: Assembly-CSharp}
       data:
         description:
           m_TableReference:

--- a/Assets/KoboldKare/Prefabs/GameManager.prefab
+++ b/Assets/KoboldKare/Prefabs/GameManager.prefab
@@ -24010,6 +24010,9 @@ MonoBehaviour:
   precisionGrabMask:
     serializedVersion: 2
     m_Bits: 33564672
+  multiGrabMask:
+    serializedVersion: 2
+    m_Bits: 33565696
   walkableGroundMask:
     serializedVersion: 2
     m_Bits: 3072

--- a/Assets/KoboldKare/Prefabs/PlayerController.prefab
+++ b/Assets/KoboldKare/Prefabs/PlayerController.prefab
@@ -1903,7 +1903,6 @@ MonoBehaviour:
   user: {fileID: 5335658201095571829}
   diePrefab: {fileID: 2324341566642796016, guid: 777f0892239272d4497bb6d3bec7061c,
     type: 3}
-  back: {fileID: -1021622891412111194, guid: b80237a58ac8c22458251d7c9dcacf88, type: 3}
   dickErectionHidable: {fileID: 6066078501566182707}
   inputRagdolled: 0
   playerDieEvent: {fileID: 11400000, guid: 01668319808ee8c48b1c39fc22f6ff84, type: 2}
@@ -4534,7 +4533,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -9.999695, y: -10}
+  m_AnchoredPosition: {x: -9.999664, y: -10}
   m_SizeDelta: {x: -20, y: 35}
   m_Pivot: {x: 1, y: 1}
 --- !u!222 &1101751689644777539
@@ -7236,7 +7235,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -9.999695, y: -48}
+  m_AnchoredPosition: {x: -9.999664, y: -48}
   m_SizeDelta: {x: -20, y: 35}
   m_Pivot: {x: 1, y: 1}
 --- !u!222 &2365030735395279601
@@ -7784,7 +7783,7 @@ CapsuleCollider:
   m_Radius: 0.4
   m_Height: 2.75
   m_Direction: 2
-  m_Center: {x: 0, y: 0, z: 0.25}
+  m_Center: {x: 0, y: 0, z: 0}
 --- !u!114 &5335658201095571829
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/KoboldKare/Scripts/BrainSwapperMachine.cs
+++ b/Assets/KoboldKare/Scripts/BrainSwapperMachine.cs
@@ -116,6 +116,18 @@ public class BrainSwapperMachine : UsableMachine, IAnimationStationSet {
             }
         }
 
+        // If one kobold is a player and the other isn't, give ALL the money to the player.
+        // This lets a player leave the lobby, rejoin, and get their money back when swapping back into their old self.
+        if (aView != null && bView != null && ((aPlayer == null) != (bPlayer == null))) {
+            if (aPlayer != null) {
+                moneyA += moneyB;
+                moneyB = 0;
+            } else {
+                moneyB += moneyA;
+                moneyA = 0;
+            }
+        }
+
         if (aView != null) {
             if (Equals(aPlayer, PhotonNetwork.LocalPlayer)) {
                 aView.GetComponent<CharacterDescriptor>().SetPlayerControlled(CharacterDescriptor.ControlType.LocalPlayer);

--- a/Assets/KoboldKare/Scripts/BrainSwapperMachine.cs
+++ b/Assets/KoboldKare/Scripts/BrainSwapperMachine.cs
@@ -89,6 +89,13 @@ public class BrainSwapperMachine : UsableMachine, IAnimationStationSet {
         stations[1].info.user.photonView.RPC(nameof(CharacterControllerAnimator.StopAnimationRPC), RpcTarget.All);
     }
 
+    private (float, float) SwapMoneyToPlayer(float playerMoney, float nonPlayerMoney) {
+        // Reserve the starting money on the non-player kobold to avoid money duplication.
+        float nonPlayerKeep = Mathf.Min(nonPlayerMoney, MoneyHolder.STARTING_MONEY);
+    
+        return (playerMoney + nonPlayerMoney - nonPlayerKeep, nonPlayerKeep);    
+    }
+
     [PunRPC]
     public void AssignKobolds(int aViewID, int bViewID, int playerIDA, int playerIDB, float moneyA, float moneyB) {
         PhotonProfiler.LogReceive(sizeof(int)*4+sizeof(float)*2);
@@ -120,11 +127,9 @@ public class BrainSwapperMachine : UsableMachine, IAnimationStationSet {
         // This lets a player leave the lobby, rejoin, and get their money back when swapping back into their old self.
         if (aView != null && bView != null && ((aPlayer == null) != (bPlayer == null))) {
             if (aPlayer != null) {
-                moneyA += moneyB;
-                moneyB = 0;
+                (moneyA, moneyB) = SwapMoneyToPlayer(moneyA, moneyB);
             } else {
-                moneyB += moneyA;
-                moneyA = 0;
+                (moneyB, moneyA) = SwapMoneyToPlayer(moneyB, moneyA);
             }
         }
 

--- a/Assets/KoboldKare/Scripts/Cheats/Command.cs
+++ b/Assets/KoboldKare/Scripts/Cheats/Command.cs
@@ -70,8 +70,9 @@ public class Command {
     protected Kobold GetAimedAtKobold(Kobold caller) {
         Vector3 aimPosition = caller.GetComponentInChildren<Animator>().GetBoneTransform(HumanBodyBones.Head).position;
         Vector3 aimDir = caller.GetComponentInChildren<CharacterControllerAnimator>(true).eyeDir;
+        float range = caller.sizeInflater.GetSize() * 5f + 1f; // Scale range by the effective height of the caller.
 
-        foreach (RaycastHit hit in Physics.RaycastAll(aimPosition, aimDir, 5f)) {
+        foreach (RaycastHit hit in Physics.RaycastAll(aimPosition, aimDir, range)) {
             Kobold k = hit.collider.GetComponentInParent<Kobold>();
             if (k != null && k != caller) return k;
         }

--- a/Assets/KoboldKare/Scripts/Cheats/Command.cs
+++ b/Assets/KoboldKare/Scripts/Cheats/Command.cs
@@ -62,4 +62,20 @@ public class Command {
     public virtual IEnumerable<AutocompleteResult> Autocomplete(int argumentIndex, string[] arguments, string text) {
         return Array.Empty<AutocompleteResult>();
     }
+
+    /// <summary>
+    /// </summary>
+    /// <param name="caller">The kobold that tried to run the command.</param>
+    /// <returns>The kobold being looked at by the caller, or null if none can be found.</returns>
+    protected Kobold GetAimedAtKobold(Kobold caller) {
+        Vector3 aimPosition = caller.GetComponentInChildren<Animator>().GetBoneTransform(HumanBodyBones.Head).position;
+        Vector3 aimDir = caller.GetComponentInChildren<CharacterControllerAnimator>(true).eyeDir;
+
+        foreach (RaycastHit hit in Physics.RaycastAll(aimPosition, aimDir, 5f)) {
+            Kobold k = hit.collider.GetComponentInParent<Kobold>();
+            if (k != null && k != caller) return k;
+        }
+
+        return null;
+    }
 }

--- a/Assets/KoboldKare/Scripts/Cheats/CommandClone.cs
+++ b/Assets/KoboldKare/Scripts/Cheats/CommandClone.cs
@@ -34,7 +34,7 @@ public class CommandClone : Command {
         BitBuffer playerSpawnData = new(16);
         playerSpawnData.AddKoboldGenes(refKobold.GetGenes());
         playerSpawnData.AddBool(false);
-        PhotonNetwork.InstantiateRoomObject(speciesName, callerTransform.position + callerTransform.forward, Quaternion.identity, 0, new object[] { playerSpawnData });
+        PhotonNetwork.Instantiate(speciesName, callerTransform.position + callerTransform.forward, Quaternion.identity, 0, new object[] { playerSpawnData });
     }
 
     public override IEnumerable<AutocompleteResult> Autocomplete(int argumentIndex, string[] arguments, string text) {

--- a/Assets/KoboldKare/Scripts/Cheats/CommandClone.cs
+++ b/Assets/KoboldKare/Scripts/Cheats/CommandClone.cs
@@ -7,9 +7,6 @@ using UnityEngine;
 
 [System.Serializable]
 public class CommandClone : Command {
-    [SerializeField]
-    private PhotonGameObjectReference koboldPrefab;
-
     private static readonly string[] arg1 = new string[]
     {
         "self",
@@ -33,11 +30,11 @@ public class CommandClone : Command {
         if (refKobold == null) throw new CheatsProcessor.CommandException("Need to be facing the kobold you want to target.");
 
         var callerTransform = caller.hip.transform;
-        string koboldName = koboldPrefab.photonName;
+        var speciesName = GameManager.GetPlayerDatabase().GetValidPrefabReferenceInfos()[refKobold.GetGenes().species].GetKey();
         BitBuffer playerSpawnData = new(16);
         playerSpawnData.AddKoboldGenes(refKobold.GetGenes());
         playerSpawnData.AddBool(false);
-        PhotonNetwork.InstantiateRoomObject(koboldName, callerTransform.position + callerTransform.forward, Quaternion.identity, 0, new object[] { playerSpawnData });
+        PhotonNetwork.InstantiateRoomObject(speciesName, callerTransform.position + callerTransform.forward, Quaternion.identity, 0, new object[] { playerSpawnData });
     }
 
     public override IEnumerable<AutocompleteResult> Autocomplete(int argumentIndex, string[] arguments, string text) {
@@ -50,10 +47,5 @@ public class CommandClone : Command {
                 yield return new(arg);
             }
         }
-    }
-
-    public override void OnValidate() {
-        base.OnValidate();
-        koboldPrefab.OnValidate();
     }
 }

--- a/Assets/KoboldKare/Scripts/Cheats/CommandClone.cs
+++ b/Assets/KoboldKare/Scripts/Cheats/CommandClone.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using System.Text;
+using System;
+using NetStack.Serialization;
+using Photon.Pun;
+using UnityEngine;
+
+[System.Serializable]
+public class CommandClone : Command {
+    [SerializeField]
+    private PhotonGameObjectReference koboldPrefab;
+
+    private static readonly string[] arg1 = new string[]
+    {
+        "self",
+        "target",
+    };
+
+    public override string GetArg0() => "/clone";
+    public override void Execute(StringBuilder output, Kobold caller, string[] args) {
+        base.Execute(output, caller, args);
+        if (!CheatsProcessor.GetCheatsEnabled()) {
+            throw new CheatsProcessor.CommandException("Cheats are not enabled, use `/cheats 1` to enable cheats.");
+        }
+        if (args.Length < 2) {
+            throw new CheatsProcessor.CommandException("Usage: /clone {self,target}");
+        }
+
+        string targetType = args[1];
+        if (targetType != "self" && targetType != "target") throw new CheatsProcessor.CommandException("Usage: /clone {self,target}");
+
+        Kobold refKobold = targetType == "self" ? caller : GetAimedAtKobold(caller);
+        if (refKobold == null) throw new CheatsProcessor.CommandException("Need to be facing the kobold you want to target.");
+
+        var callerTransform = caller.hip.transform;
+        string koboldName = koboldPrefab.photonName;
+        BitBuffer playerSpawnData = new(16);
+        playerSpawnData.AddKoboldGenes(refKobold.GetGenes());
+        playerSpawnData.AddBool(false);
+        PhotonNetwork.InstantiateRoomObject(koboldName, callerTransform.position + callerTransform.forward, Quaternion.identity, 0, new object[] { playerSpawnData });
+    }
+
+    public override IEnumerable<AutocompleteResult> Autocomplete(int argumentIndex, string[] arguments, string text) {
+        if(argumentIndex != 1) {
+            yield break;
+        }
+
+        foreach(var arg in arg1) {
+            if (arg.Contains(text, StringComparison.OrdinalIgnoreCase)) {
+                yield return new(arg);
+            }
+        }
+    }
+
+    public override void OnValidate() {
+        base.OnValidate();
+        koboldPrefab.OnValidate();
+    }
+}

--- a/Assets/KoboldKare/Scripts/Cheats/CommandClone.cs.meta
+++ b/Assets/KoboldKare/Scripts/Cheats/CommandClone.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5b97c00f0e1bebe45bfd319de3f0b746
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/Cheats/CommandDick.cs
+++ b/Assets/KoboldKare/Scripts/Cheats/CommandDick.cs
@@ -6,6 +6,7 @@ using Photon.Pun;
 [Serializable]
 public class CommandDick : Command {
     public const short unEquipID = 0;
+    public const string unEquipName = "None";
 
     public override string GetArg0() => "/dick";
 
@@ -17,6 +18,13 @@ public class CommandDick : Command {
         if (args.Length != 2) {
             throw new CheatsProcessor.CommandException("Usage: /dick <index or name>.");
         }
+
+        // Shortcut for dick unequip, so that it has an actual name instead of only being selectable via ID 0.
+        if (args[1] == unEquipName) {
+            SetDickByID(output, k, new(), unEquipID);
+            return;
+        }
+
         var infos = GameManager.GetPenisDatabase().GetValidPrefabReferenceInfos();
         // Dick setting
         if (short.TryParse(args[1], out short dickID)) {
@@ -34,6 +42,12 @@ public class CommandDick : Command {
             yield break;
         }
 
+        // Handle unequip autocomplete manually.
+        if (unEquipName.Contains(text, StringComparison.OrdinalIgnoreCase)) {
+            yield return new(unEquipName);
+        }
+
+        // Everything else.
         var infos = GameManager.GetPenisDatabase().GetValidPrefabReferenceInfos();
 
         foreach(var info in infos) {

--- a/Assets/KoboldKare/Scripts/Cheats/CommandFlush.cs
+++ b/Assets/KoboldKare/Scripts/Cheats/CommandFlush.cs
@@ -1,0 +1,53 @@
+using Photon.Realtime;
+using System.Collections.Generic;
+using System.Text;
+using System;
+using Photon.Pun;
+
+[System.Serializable]
+public class CommandFlush : Command {
+    private static readonly string[] arg1 = new string[]
+    {
+        "self",
+        "target",
+    };
+
+    public override string GetArg0() => "/flush";
+    public override void Execute(StringBuilder output, Kobold caller, string[] args) {
+        base.Execute(output, caller, args);
+        if (!CheatsProcessor.GetCheatsEnabled()) {
+            throw new CheatsProcessor.CommandException("Cheats are not enabled, use `/cheats 1` to enable cheats.");
+        }
+        if (args.Length < 2) {
+            throw new CheatsProcessor.CommandException("Usage: /flush {self,target}");
+        }
+
+        string targetType = args[1];
+        if (targetType != "self" && targetType != "target") throw new CheatsProcessor.CommandException("Usage: /flush {self,target}");
+
+        Kobold target = targetType == "self" ? caller : GetAimedAtKobold(caller);
+        if (target == null) throw new CheatsProcessor.CommandException("Need to be facing the kobold you want to target.");
+
+        if (caller != (Kobold)PhotonNetwork.MasterClient.TagObject) {
+            foreach (Player player in PhotonNetwork.PlayerList) {
+                if ((Kobold)player.TagObject == target) {
+                    throw new CheatsProcessor.CommandException("Not the owner, not allowed to modify players.");
+                }
+            }
+        }
+
+        target.photonView.RPC(nameof(GenericReagentContainer.Spill), RpcTarget.All, target.bellyContainer.volume);
+    }
+
+    public override IEnumerable<AutocompleteResult> Autocomplete(int argumentIndex, string[] arguments, string text) {
+        if(argumentIndex != 1) {
+            yield break;
+        }
+
+        foreach(var arg in arg1) {
+            if (arg.Contains(text, StringComparison.OrdinalIgnoreCase)) {
+                yield return new(arg);
+            }
+        }
+    }
+}

--- a/Assets/KoboldKare/Scripts/Cheats/CommandFlush.cs
+++ b/Assets/KoboldKare/Scripts/Cheats/CommandFlush.cs
@@ -28,7 +28,7 @@ public class CommandFlush : Command {
         Kobold target = targetType == "self" ? caller : GetAimedAtKobold(caller);
         if (target == null) throw new CheatsProcessor.CommandException("Need to be facing the kobold you want to target.");
 
-        if (caller != (Kobold)PhotonNetwork.MasterClient.TagObject) {
+        if (caller != target && caller != (Kobold)PhotonNetwork.MasterClient.TagObject) {
             foreach (Player player in PhotonNetwork.PlayerList) {
                 if ((Kobold)player.TagObject == target) {
                     throw new CheatsProcessor.CommandException("Not the owner, not allowed to modify players.");

--- a/Assets/KoboldKare/Scripts/Cheats/CommandFlush.cs.meta
+++ b/Assets/KoboldKare/Scripts/Cheats/CommandFlush.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1f05761a24a764c46b1fa80a160937eb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/Cheats/CommandList.cs
+++ b/Assets/KoboldKare/Scripts/Cheats/CommandList.cs
@@ -60,6 +60,7 @@ public class CommandList : Command {
         }
         if (args.Length == 1 || args[1] == "dicks") {
             output.Append("Dicks = {\n");
+            output.Append($"{CommandDick.unEquipName},\n"); // Specifically list the unequip option, as it isn't in the database.
             foreach (var info in GameManager.GetPenisDatabase().GetValidPrefabReferenceInfos()) {
                 output.Append($"{info.GetKey()},\n");
             }

--- a/Assets/KoboldKare/Scripts/Cheats/CommandSculpt.cs
+++ b/Assets/KoboldKare/Scripts/Cheats/CommandSculpt.cs
@@ -78,19 +78,7 @@ public class CommandSculpt : Command
         if (targetType == "self") {
             target = k;
         } else if (targetType == "target") {
-            Vector3 aimPosition = k.GetComponentInChildren<Animator>().GetBoneTransform(HumanBodyBones.Head).position;
-            Vector3 aimDir = k.GetComponentInChildren<CharacterControllerAnimator>(true).eyeDir;
-
-            foreach (RaycastHit hit in Physics.RaycastAll(aimPosition, aimDir, 5f)) {
-                Kobold b = hit.collider.GetComponentInParent<Kobold>();
-
-                if (b == null) continue;
-                if (b == k) continue;
-
-                target = b;
-
-                break;
-            }
+            target = GetAimedAtKobold(k);
 
             if(target == null) {
                 throw new CheatsProcessor.CommandException("Need to be facing the kobold you want to target with.");

--- a/Assets/KoboldKare/Scripts/Cheats/CommandSculpt.cs
+++ b/Assets/KoboldKare/Scripts/Cheats/CommandSculpt.cs
@@ -21,6 +21,7 @@ public class CommandSculpt : Command
         "bellycapacity",
         "boobs",
         "brightness",
+        "clothinghue",
         "dick",
         "dickthickness",
         "energy",

--- a/Assets/KoboldKare/Scripts/Cheats/CommandSculpt.cs
+++ b/Assets/KoboldKare/Scripts/Cheats/CommandSculpt.cs
@@ -27,11 +27,11 @@ public class CommandSculpt : Command
         "energy",
         "fat",
         "foodcapacity",
+        "grabcount",
         "height",
         "hue",
         "impregnate",
         "saturation",
-        "grabcount",
     };
 
     public override string GetArg0() => "/sculpt";

--- a/Assets/KoboldKare/Scripts/Cheats/CommandSculpt.cs
+++ b/Assets/KoboldKare/Scripts/Cheats/CommandSculpt.cs
@@ -30,6 +30,7 @@ public class CommandSculpt : Command
         "hue",
         "impregnate",
         "saturation",
+        "grabcount",
     };
 
     public override string GetArg0() => "/sculpt";
@@ -38,7 +39,7 @@ public class CommandSculpt : Command
         base.Execute(output, k, args);
 
         static void Usage() {
-            throw new CheatsProcessor.CommandException("Usage: /sculpt {self,target} {dick,balls,boobs,height,fat,foodcapacity,bellycapacity,dickthickness,energy,clothinghue,hue,brightness,saturation,impregnate} [set] {modifier} (set is optional)");
+            throw new CheatsProcessor.CommandException("Usage: /sculpt {self,target} {dick,balls,boobs,height,fat,foodcapacity,bellycapacity,dickthickness,energy,clothinghue,hue,brightness,saturation,impregnate,grabcount} [set] {modifier} (set is optional)");
         }
 
         if (!CheatsProcessor.GetCheatsEnabled()) {
@@ -227,6 +228,12 @@ public class CommandSculpt : Command
 
                     target.bellyContainer.AddMix(alloc, GenericReagentContainer.InjectType.Inject);
                 }
+
+                break;
+            
+            case "grabcount":
+
+                target.SetGenes(genes.With(grabCount: SafeModify(genes.grabCount, Mathf.Max(modifier, 1f))));
 
                 break;
 

--- a/Assets/KoboldKare/Scripts/Cheats/CommandSwap.cs
+++ b/Assets/KoboldKare/Scripts/Cheats/CommandSwap.cs
@@ -19,29 +19,24 @@ public class CommandSwap : Command {
             throw new CheatsProcessor.CommandException("Couldn't find the brain swapper machine, its required to exist in the world in order to trigger a swap...");
         }
 
-        Vector3 aimPosition = k.GetComponentInChildren<Animator>().GetBoneTransform(HumanBodyBones.Head).position;
-        Vector3 aimDir = k.GetComponentInChildren<CharacterControllerAnimator>(true).eyeDir;
-        foreach (RaycastHit hit in Physics.RaycastAll(aimPosition, aimDir, 5f)) {
-            Kobold b = hit.collider.GetComponentInParent<Kobold>();
-            if (b == null) continue;
-            if (b == k) continue;
-            Player aPlayer = null;
-            Player bPlayer = null;
-            foreach (Player player in PhotonNetwork.PlayerList) {
-                if ((Kobold)player.TagObject == k) {
-                    aPlayer = player;
-                }
+        Kobold b = GetAimedAtKobold(k);
+        if (k == null) throw new CheatsProcessor.CommandException("Need to be facing the kobold you want to swap with.");
 
-                if ((Kobold)player.TagObject == b) {
-                    bPlayer = player;
-                }
+        Player aPlayer = null;
+        Player bPlayer = null;
+        foreach (Player player in PhotonNetwork.PlayerList) {
+            if ((Kobold)player.TagObject == k) {
+                aPlayer = player;
             }
-            machine.photonView.RPC(nameof(BrainSwapperMachine.AssignKobolds), RpcTarget.All, k.photonView.ViewID,
-                b.photonView.ViewID, bPlayer?.ActorNumber ?? -1, aPlayer?.ActorNumber ?? -1,
-                b.GetComponent<MoneyHolder>().GetMoney(), k.GetComponent<MoneyHolder>().GetMoney());
-            output.Append($"Swapped kobolds.\n");
-            return;
+
+            if ((Kobold)player.TagObject == b) {
+                bPlayer = player;
+            }
         }
-        throw new CheatsProcessor.CommandException("Need to be facing the kobold you want to swap with.");
+
+        machine.photonView.RPC(nameof(BrainSwapperMachine.AssignKobolds), RpcTarget.All, k.photonView.ViewID,
+            b.photonView.ViewID, bPlayer?.ActorNumber ?? -1, aPlayer?.ActorNumber ?? -1,
+            b.GetComponent<MoneyHolder>().GetMoney(), k.GetComponent<MoneyHolder>().GetMoney());
+        output.Append($"Swapped kobolds.\n");
     }
 }

--- a/Assets/KoboldKare/Scripts/Cheats/CommandSwap.cs
+++ b/Assets/KoboldKare/Scripts/Cheats/CommandSwap.cs
@@ -20,7 +20,7 @@ public class CommandSwap : Command {
         }
 
         Kobold b = GetAimedAtKobold(k);
-        if (k == null) throw new CheatsProcessor.CommandException("Need to be facing the kobold you want to swap with.");
+        if (b == null) throw new CheatsProcessor.CommandException("Need to be facing the kobold you want to swap with.");
 
         Player aPlayer = null;
         Player bPlayer = null;

--- a/Assets/KoboldKare/Scripts/Cheats/CommandView.cs
+++ b/Assets/KoboldKare/Scripts/Cheats/CommandView.cs
@@ -98,6 +98,7 @@ public class CommandView : Command
             case "all":
                 output.Append($"The stats are currently\n");
 
+                // TODO: This works fine in-editor, but nothing from this for loop shows up when tested in a built game. Needs further debugging.
                 foreach (string sn in statNames) {
                     int spaceCount = statNameMaxLength - sn.Length;
                     spaceCount = (int)(spaceCount * 1.8f); // The chat font isn't monospaced, have to approximate it :(

--- a/Assets/KoboldKare/Scripts/Cheats/CommandView.cs
+++ b/Assets/KoboldKare/Scripts/Cheats/CommandView.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+[System.Serializable]
+public class CommandView : Command
+{
+    private static readonly string[] arg1 = new string[]
+    {
+        "self",
+        "target",
+    };
+
+    private static readonly string[] statNames = new string[]
+    {
+        "balls",
+        "bellycapacity",
+        "boobs",
+        "brightness",
+        "clothinghue",
+        "dick",
+        "dickthickness",
+        "dicktype",
+        "energy",
+        "fat",
+        "foodcapacity",
+        "grabcount",
+        "height",
+        "hue",
+        "saturation",
+        "species",
+    };
+
+    private static readonly string[] multiStatNames = new string[]
+    {
+        "all",
+        "hsv",
+        "chsv",
+    };
+
+    private static string GetStatString(Kobold target, String statName) {
+        return statName switch
+        {
+            "balls"         => string.Format("{0:f}", target.GetGenes().ballSize),
+            "bellycapacity" => string.Format("{0:f}", target.GetGenes().bellySize),
+            "boobs"         => string.Format("{0:f}", target.GetGenes().breastSize),
+            "brightness"    => string.Format("{0:d}", target.GetGenes().brightness),
+            "clothinghue"   => string.Format("{0:d}", target.GetGenes().clothingHue),
+            "dick"          => string.Format("{0:f}", target.GetGenes().dickSize),
+            "dickthickness" => string.Format("{0:f}", target.GetGenes().dickThickness),
+            "dicktype"      => target.GetGenes().dickEquip == 0 ? CommandDick.unEquipName : GameManager.GetPenisDatabase().GetValidPrefabReferenceInfos()[target.GetGenes().dickEquip - 1].GetKey(),
+            "energy"        => string.Format("{0:f}", target.GetGenes().maxEnergy),
+            "fat"           => string.Format("{0:f}", target.GetGenes().fatSize),
+            "foodcapacity"  => string.Format("{0:f}", target.GetGenes().metabolizeCapacitySize),
+            "grabcount"     => string.Format("{0:d}", target.GetGenes().grabCount),
+            "height"        => string.Format("{0:f}", target.GetGenes().baseSize),
+            "hue"           => string.Format("{0:d}", target.GetGenes().hue),
+            "saturation"    => string.Format("{0:d}", target.GetGenes().saturation),
+            "species"       => GameManager.GetPlayerDatabase().GetValidPrefabReferenceInfos()[target.GetGenes().species].GetKey(),
+            _ => throw new CheatsProcessor.CommandException($"Invalid stat specified: {statName}"),
+        };
+    }
+
+    private static int statNameMaxLength = 0;
+
+    public override string GetArg0() => "/view";
+
+    public override void Execute(StringBuilder output, Kobold caller, string[] args) {
+        base.Execute(output, caller, args);
+
+        static void Usage() {
+            throw new CheatsProcessor.CommandException("Usage: /view {self,target} {all,dick,dicktype,balls,boobs,height,fat,foodcapacity,bellycapacity,dickthickness,energy,clothinghue,hue,saturation,grabcount,species,hsv,chsv}");
+        }
+
+        if (!CheatsProcessor.GetCheatsEnabled()) {
+            throw new CheatsProcessor.CommandException("Cheats are not enabled, use `/cheats 1` to enable cheats.");
+        }
+
+        if (args.Length != 3) {
+            Usage();
+        }
+
+        string targetType = args[1];
+        if (targetType != "self" && targetType != "target") Usage();
+
+        Kobold target = targetType == "self" ? caller : GetAimedAtKobold(caller);
+        if (target == null) throw new CheatsProcessor.CommandException("Need to be facing the kobold you want to target.");
+
+        var statName = args[2].ToLowerInvariant();
+
+        switch (statName) {
+            case "dicktype":
+                output.Append($"The dick type is currently {GetStatString(target, statName)}\n");
+                break;
+            case "species":
+                output.Append($"The species is {GetStatString(target, statName)}\n");
+                break;
+            case "all":
+                output.Append($"The stats are currently\n");
+
+                foreach (string sn in statNames) {
+                    int spaceCount = statNameMaxLength - sn.Length;
+                    spaceCount = (int)(spaceCount * 1.8f); // The chat font isn't monospaced, have to approximate it :(
+                    string padding = new(' ', spaceCount);
+
+                    //output.Append($"  {sn,-15} {GetStatString(target, sn)}\n"); // TODO: If the chat ever switches to a monospaced font, use this instead and fix the other alignments.
+                    output.Append($"  {sn}{padding}     {GetStatString(target, sn)}\n");
+                }
+
+                break;
+            case "hsv":
+                output.Append($"The HSV values are currently\n");
+                output.Append($"  hue              {GetStatString(target, "hue")}\n");
+                output.Append($"  saturation   {GetStatString(target, "saturation")}\n");
+                output.Append($"  brightness  {GetStatString(target, "brightness")}\n");
+
+                break;
+            case "chsv":
+                output.Append($"The CHSV values are currently\n");
+                output.Append($"  clothinghue   {GetStatString(target, "clothinghue")}\n");
+                output.Append($"  hue                  {GetStatString(target, "hue")}\n");
+                output.Append($"  saturation      {GetStatString(target, "saturation")}\n");
+                output.Append($"  brightness     {GetStatString(target, "brightness")}\n");
+
+                break;
+            default:
+                output.Append($"The {statName} stat is currently {GetStatString(target, statName)}\n");
+                break;
+        }
+    }
+
+    public override IEnumerable<AutocompleteResult> Autocomplete(int argumentIndex, string[] arguments, string text) {
+        if (!CheatsProcessor.GetCheatsEnabled()) {
+            yield break;
+        }
+        switch(argumentIndex) {
+            case 1:
+                foreach(var arg in arg1) {
+                    if (arg.Contains(text, StringComparison.OrdinalIgnoreCase)) {
+                        yield return new(arg);
+                    }
+                }
+                break;
+            case 2:
+                foreach (var arg in statNames) {
+                    if (arg.Contains(text, StringComparison.OrdinalIgnoreCase)) {
+                        yield return new(arg);
+                    }
+                }
+
+                foreach (var arg in multiStatNames) {
+                    if (arg.Contains(text, StringComparison.OrdinalIgnoreCase)) {
+                        yield return new(arg);
+                    }
+                }
+                break;
+        }
+    }
+
+    public override void OnValidate() {
+        base.OnValidate();
+
+        foreach (var statName in statNames) {
+            statNameMaxLength = Math.Max(statNameMaxLength, statName.Length);
+        }
+    }
+}

--- a/Assets/KoboldKare/Scripts/Cheats/CommandView.cs.meta
+++ b/Assets/KoboldKare/Scripts/Cheats/CommandView.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e3faa15f5783b384b988b20d2cb64dec
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/KoboldKare/Scripts/FloatTextDisplay.cs
+++ b/Assets/KoboldKare/Scripts/FloatTextDisplay.cs
@@ -29,7 +29,9 @@ public class FloatTextDisplay : MonoBehaviour {
         if (routine != null) {
             StopCoroutine(routine);
         }
-        routine = StartCoroutine(MoneyUpdateRoutine(oldMoney, newMoney));
+        if (text.IsActive()) {
+            routine = StartCoroutine(MoneyUpdateRoutine(oldMoney, newMoney));
+        }
     }
     IEnumerator MoneyUpdateRoutine(float from, float to) {
         float startTime = Time.time;

--- a/Assets/KoboldKare/Scripts/GameManager.cs
+++ b/Assets/KoboldKare/Scripts/GameManager.cs
@@ -20,6 +20,7 @@ public class GameManager : MonoBehaviour {
     public AudioMixerGroup soundEffectGroup;
     public AudioMixerGroup soundEffectLoudGroup;
     public LayerMask precisionGrabMask;
+    public LayerMask multiGrabMask;
     public LayerMask walkableGroundMask;
     public LayerMask waterSprayHitMask;
     public LayerMask plantHitMask;

--- a/Assets/KoboldKare/Scripts/Grabber.cs
+++ b/Assets/KoboldKare/Scripts/Grabber.cs
@@ -343,7 +343,7 @@ public class Grabber : MonoBehaviourPun {
         }
     }
 
-    private Vector3 GetViewPos() {
+    private Vector3 GetViewPos(float offsetScale = 1f) {
         if (PlayerPossession.TryGetPlayerInstance(out var poss) && poss.kobold == player) {
             var desiredViewDistance = 1f;
             if (poss.TryGetComponent<CameraSwitcher>(out var cameraSwitcher)) {
@@ -357,7 +357,7 @@ public class Grabber : MonoBehaviourPun {
             }
 
             const float fudgeDistance = 3f;
-            var cameraPos = OrbitCamera.GetCamera().transform.position + OrbitCamera.GetPlayerIntendedRotation()*defaultOffset*desiredViewDistance;
+            var cameraPos = OrbitCamera.GetCamera().transform.position + OrbitCamera.GetPlayerIntendedRotation()*defaultOffset*desiredViewDistance*offsetScale;
             float distance = Vector3.Distance(view.position, cameraPos);
             Vector3 viewPos = Vector3.MoveTowards(cameraPos, view.position, Mathf.Max(distance - fudgeDistance, 0f));
             return viewPos;
@@ -375,9 +375,24 @@ public class Grabber : MonoBehaviourPun {
             return;
         }
 
-        var position = GetViewPos()+OrbitCamera.GetPlayerIntendedRotation()*defaultOffset;
-        int hits = Physics.OverlapSphereNonAlloc(position, 1f, colliders);
-        sorter.SetRay(new Ray(position, OrbitCamera.GetPlayerIntendedRotation()*Vector3.forward));
+        Quaternion aimQuat = OrbitCamera.GetPlayerIntendedRotation();
+        Vector3 viewPos = GetViewPos();
+        Vector3 aimDir = aimQuat * Vector3.forward;
+        Vector3 searchCenter;
+
+        float plyScale = player.sizeInflater.GetSize();
+        float range = plyScale * 1.35f;
+        float sphereRadius = Mathf.Clamp(plyScale, 1f, 3f);
+
+        // Decide how far out to do the sphere search with a raycast that scales with effective kobold height.
+        if (Physics.Raycast(viewPos, aimDir, out RaycastHit rayHit, range, GameManager.instance.multiGrabMask, QueryTriggerInteraction.Ignore)) {
+            searchCenter = rayHit.point;
+        } else {
+            searchCenter = viewPos + aimDir * range;
+        }
+
+        int hits = Physics.OverlapSphereNonAlloc(searchCenter, sphereRadius, colliders);
+        sorter.SetRay(new Ray(searchCenter, aimDir));
         System.Array.Sort(colliders, 0, hits, sorter);
         for (int i = 0; i < hits; i++) {
             IGrabbable grabbable = colliders[i].GetComponentInParent<IGrabbable>();
@@ -398,7 +413,7 @@ public class Grabber : MonoBehaviourPun {
 
             if (grabbable.CanGrab(player)) {
                 grabbable.photonView.RPC(nameof(IGrabbable.OnGrabRPC), RpcTarget.All, photonView.ViewID);
-                GrabInfo info = new GrabInfo(player, grabbable, springStrength, dampingStrength, GetViewPos(),OrbitCamera.GetPlayerIntendedRotation(), defaultOffset);
+                GrabInfo info = new GrabInfo(player, grabbable, springStrength, dampingStrength, GetViewPos(1f),OrbitCamera.GetPlayerIntendedRotation(), defaultOffset);
                 // Destroyed on grab, creatures gib on grab.
                 if (!info.Valid()) {
                     return;
@@ -415,8 +430,17 @@ public class Grabber : MonoBehaviourPun {
 
     public void LateUpdate() {
         Validate();
-        foreach (var grab in grabbedObjects) {
-            grab.Set(GetViewPos(), OrbitCamera.GetPlayerIntendedRotation(), defaultOffset);
+
+        if (grabbedObjects.Count != 0) {
+            // Scale hold distance so it doesn't leave the interaction range of small kobolds, and isn't too close to big kobolds.
+            float holdDist = Math.Min(player.sizeInflater.GetSize(), 1.25f) * 1.6f + 0.4f;
+            Vector3 origin = GetViewPos(0f); // clamped camera position without any forwards offset
+            Vector3 offset = defaultOffset * holdDist;
+
+            // Update positions.
+            foreach (var grab in grabbedObjects) {
+                grab.Set(origin, OrbitCamera.GetPlayerIntendedRotation(), offset);
+            }
         }
     }
     public void TryStopActivate() {

--- a/Assets/KoboldKare/Scripts/MoneyHolder.cs
+++ b/Assets/KoboldKare/Scripts/MoneyHolder.cs
@@ -6,13 +6,16 @@ using SimpleJSON;
 using UnityEngine;
 
 public class MoneyHolder : MonoBehaviourPun, ISavable, IPunObservable, IValuedGood {
+#if UNITY_EDITOR
+    public const float STARTING_MONEY = 150f;
+#else
+    public const float STARTING_MONEY = 150f;
+#endif
+
     public delegate void MoneyChangedAction(float newMoney);
     public MoneyChangedAction moneyChanged;
-#if UNITY_EDITOR
-    private float money = 150f;
-#else
-    private float money = 5f;
-#endif
+    private float money = STARTING_MONEY;
+
     public float GetMoney() => money;
 
     public void SetMoney(float amount) {

--- a/Assets/KoboldKare/Scripts/MoneyHolder.cs
+++ b/Assets/KoboldKare/Scripts/MoneyHolder.cs
@@ -17,6 +17,7 @@ public class MoneyHolder : MonoBehaviourPun, ISavable, IPunObservable, IValuedGo
 
     public void SetMoney(float amount) {
         money = amount;
+        moneyChanged?.Invoke(money);
     }
 
     [PunRPC]

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentContents.cs
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentContents.cs
@@ -65,7 +65,6 @@ public class ReagentContents : IEnumerable<Reagent> {
         }
         changed?.Invoke(this);
     }
-    private const float metabolizationVolumeEpsilon = 0.1f;
     public float volume {
         get {
             float v = 0f;
@@ -139,20 +138,19 @@ public class ReagentContents : IEnumerable<Reagent> {
         }
         foreach(var pair in contents) {
             float metabolizationHalfLife = 0f;
+            float metabolizationFlatRate = 0f;
             if (ReagentDatabase.TryGetAsset(pair.Key, out var reagent)) {
                 metabolizationHalfLife = reagent.GetMetabolizationHalfLife();
+                metabolizationFlatRate = reagent.GetMetabolizationFlatRate();
             }
 
-            float metaHalfLife = metabolizationHalfLife == 0 ? pair.Value.volume : pair.Value.volume * Mathf.Pow(0.5f, deltaTime / metabolizationHalfLife);
-            // halflife on a tiny value suuucks, just kill it if the value gets small enough so we don't spam incredibly tiny updates.
-            if (pair.Value.volume <= metabolizationVolumeEpsilon) {
-                metabolizeContents.AddMix(pair.Value);
-                contents[pair.Key].volume = 0f;
-                continue;
-            }
-            float loss = Mathf.Max(pair.Value.volume - metaHalfLife, 0f);
-            contents[pair.Key].volume = Mathf.Max(metaHalfLife, 0f);
-            metabolizeContents.AddMix(pair.Key, loss);
+            float curVolume = pair.Value.volume;
+            float halfLifeKeep = metabolizationHalfLife == 0f ? curVolume : curVolume * Mathf.Pow(0.5f, deltaTime / metabolizationHalfLife);
+            float flatRateLoss = deltaTime * metabolizationFlatRate; // Tiny constant loss since half life is terrible on small values.
+            float newVolume = Mathf.Max(0f, halfLifeKeep - flatRateLoss);
+
+            contents[pair.Key].volume = newVolume;
+            metabolizeContents.AddMix(pair.Key, curVolume - newVolume);
         }
         changed?.Invoke(this);
         return metabolizeContents;

--- a/Assets/KoboldKare/Scripts/Reagents/ReagentContents.cs
+++ b/Assets/KoboldKare/Scripts/Reagents/ReagentContents.cs
@@ -65,6 +65,7 @@ public class ReagentContents : IEnumerable<Reagent> {
         }
         changed?.Invoke(this);
     }
+    private const float metabolizationVolumeEpsilon = 0.4f;
     public float volume {
         get {
             float v = 0f;
@@ -148,6 +149,11 @@ public class ReagentContents : IEnumerable<Reagent> {
             float halfLifeKeep = metabolizationHalfLife == 0f ? curVolume : curVolume * Mathf.Pow(0.5f, deltaTime / metabolizationHalfLife);
             float flatRateLoss = deltaTime * metabolizationFlatRate; // Tiny constant loss since half life is terrible on small values.
             float newVolume = Mathf.Max(0f, halfLifeKeep - flatRateLoss);
+
+            // Snap to zero when extremely small, since at this point it's hard to see on the HUD if the fluid is truly gone or not.
+            if (newVolume < metabolizationVolumeEpsilon) {
+                newVolume = 0f;
+            }
 
             contents[pair.Key].volume = newVolume;
             metabolizeContents.AddMix(pair.Key, curVolume - newVolume);

--- a/Assets/KoboldKare/Scripts/Reagents/ScriptableReagent.cs
+++ b/Assets/KoboldKare/Scripts/Reagents/ScriptableReagent.cs
@@ -18,6 +18,8 @@ public class ScriptableReagent : ScriptableObject {
     [SerializeField]
     private float metabolizationHalfLife;
     [SerializeField]
+    private float metabolizationFlatRate = 0.05f;
+    [SerializeField]
     private bool cleaningAgent;
     [SerializeField]
     private float calories = 0f;
@@ -31,6 +33,7 @@ public class ScriptableReagent : ScriptableObject {
     public Color GetColorEmission() => emission;
     public float GetValue() => value;
     public float GetMetabolizationHalfLife() => metabolizationHalfLife;
+    public float GetMetabolizationFlatRate() => metabolizationFlatRate;
     public bool IsCleaningAgent() => cleaningAgent;
     public float GetCalories() => calories;
     public GameObject GetDisplayPrefab() => display;

--- a/Assets/KoboldKare/Scripts/User.cs
+++ b/Assets/KoboldKare/Scripts/User.cs
@@ -34,10 +34,11 @@ public class User : MonoBehaviourPun {
         var ownedKobold = kobold;
         if (!photonView.IsMine || (Kobold)PhotonNetwork.LocalPlayer.TagObject != ownedKobold) return;
         transform.rotation = OrbitCamera.GetPlayerIntendedRotation();
-        
-        var desiredPosition = OrbitCamera.GetCamera().transform.position + transform.forward * (capsuleCollider.height*0.5f);
+
+        var desiredPosition = OrbitCamera.GetCamera().transform.position + transform.TransformVector(new(0f, 0f, capsuleCollider.height * 0.5f));
         float distance = Vector3.Distance(ownedKobold.transform.position, desiredPosition);
-        transform.position = Vector3.MoveTowards(desiredPosition, ownedKobold.transform.position, Mathf.Max(distance - ownedKobold.GetGenes().baseSize*0.2f, 0f));
+        float desiredReach = kobold.sizeInflater.GetSize() * 3.8f + 0.2f;
+        transform.position = Vector3.MoveTowards(desiredPosition, ownedKobold.transform.position, Mathf.Max(distance - desiredReach, 0f));
     }
 
     public IEnumerator WaitAndThenTrigger(UnityEvent e) {
@@ -58,7 +59,6 @@ public class User : MonoBehaviourPun {
         }
     }
     void FixedUpdate() {
-        capsuleCollider.height = kobold.GetGenes().baseSize * 0.20f;
         SortGrabbables();
         possibleUsables.Clear();
     }

--- a/Assets/KoboldKare/Scripts/User.cs
+++ b/Assets/KoboldKare/Scripts/User.cs
@@ -36,10 +36,11 @@ public class User : MonoBehaviourPun {
         transform.rotation = OrbitCamera.GetPlayerIntendedRotation();
 
         // Move the user towards the camera, but limit it by the kobold's effective size so they can't abuse freecam.
-        var desiredPosition = OrbitCamera.GetCamera().transform.position + transform.TransformVector(new(0f, 0f, capsuleCollider.height * 0.5f));
-        float distance = Vector3.Distance(ownedKobold.transform.position, desiredPosition);
+        Vector3 desiredPosition = OrbitCamera.GetCamera().transform.position + transform.TransformVector(new(0f, 0f, capsuleCollider.height * 0.5f));
+        Vector3 anchorPosition = ownedKobold.transform.position;
+        float distance = Vector3.Distance(anchorPosition, desiredPosition);
         float desiredReach = kobold.sizeInflater.GetSize() * 3.8f + 0.2f;
-        transform.position = Vector3.MoveTowards(desiredPosition, ownedKobold.transform.position, Mathf.Max(distance - desiredReach, 0f));
+        transform.position = Vector3.MoveTowards(desiredPosition, anchorPosition, Mathf.Max(distance - desiredReach, 0f));
     }
 
     public IEnumerator WaitAndThenTrigger(UnityEvent e) {

--- a/Assets/KoboldKare/Scripts/User.cs
+++ b/Assets/KoboldKare/Scripts/User.cs
@@ -35,6 +35,7 @@ public class User : MonoBehaviourPun {
         if (!photonView.IsMine || (Kobold)PhotonNetwork.LocalPlayer.TagObject != ownedKobold) return;
         transform.rotation = OrbitCamera.GetPlayerIntendedRotation();
 
+        // Move the user towards the camera, but limit it by the kobold's effective size so they can't abuse freecam.
         var desiredPosition = OrbitCamera.GetCamera().transform.position + transform.TransformVector(new(0f, 0f, capsuleCollider.height * 0.5f));
         float distance = Vector3.Distance(ownedKobold.transform.position, desiredPosition);
         float desiredReach = kobold.sizeInflater.GetSize() * 3.8f + 0.2f;


### PR DESCRIPTION
An assortment of quality of life tweaks/fixes too small to put into their own PRs.

- Adds a slow 0.05/s constant rate to stomach processing.
  - For most reagents, this shaves off about a minute of waiting for fluids to go from a volume of ~1 unit down to fully digested.
  - Gets overshadowed by half-life decay for larger volumes, so the long term digestion speed is relatively unaffected.
  - Mostly serves to make the press/toilet not basically mandatory every time you take in any fluid, and to reduce empty downtime waiting for a tiny sliver of fluid to finally finish up.
- Changes `metabolizationVolumeEpsilon` from 0.1 to 0.4 since any volume around 0.5 or less is practically invisible on the HUD.
- Adds `grabcount` to `/sculpt` and fixes `clothinghue` being missing from the autocomplete list.
- When swapping, if one kobold is player-controlled and the other is not, the swap now gives all of the non-player’s money to the player kobold.
  - This is for when a player has to leave and rejoin a lobby, letting them get their money back without needing cheats.
  - The non-player kobold will still hold onto the starting money value at minimum, so players don't get a free $5 each time they swap into a new kobold.
- Moves the kobold raytracing from `/swap` and `/sculpt` into a helper function in `Command`.
  - Also changes the raytrace to make it scale properly with the kobold's effective height, plus a small flat bonus so tiny kobolds don't suffer. No more being out of swap range as a large kobold!
- Adds a `/clone` command to immediately produce a clone of self/target.
- Adds a `/flush` command to empty the stomach of self/target.
- Adds a `/view` command which prints the stats, species, and/or dick type of self/target.
  - Specific parts/stats can be specified, like with `/sculpt`.
  - Passing `all` will print all stats.
  - Due to the chat font not being monospaced, the alignment when printing multiple stats isn't perfect, and adds some extra jank to the string building. If the font ever gets changed, this can be fixed easily, but it's otherwise not a big deal.
- Adds `None` as an option to `/dick` to make it more apparent to players that they can remove their dick.
  - Previously, this was only possible with id 0, which isn't mentioned unless you get a specific command fail message.
- Fixes interaction range so it properly scales with the kobold's effective height instead of (pseudocode) `effectiveHeight * sizeStatWithoutLogFalloff`.
  - No more will being large cause you to get tons of quickly-changing interaction previews from the other side of the farm.
  - The section which moves the interaction hitbox towards the camera also has its range scaling fixed.
- Makes grabbing scale with effective kobold height instead of being a constant length.
  - The distance at which objects are held also gets scaled, with an upper limit for large kobolds.