### PR TITLE
Fix text element index mismatch in WordFilter.GetBlackListed

### DIFF
--- a/Packages/com.naelstrof.word-filter/Tests/WordFilterTests.cs
+++ b/Packages/com.naelstrof.word-filter/Tests/WordFilterTests.cs
@@ -1,0 +1,143 @@
+using System.Globalization;
+using NUnit.Framework;
+
+namespace WordFilter.Tests {
+
+[TestFixture]
+public class WordFilterTests {
+    private static readonly string[] TestBlacklist = new[] { "bad", "evil" };
+
+    // --- Basic detection ---
+
+    [Test]
+    public void DetectsExactBannedWord() {
+        bool result = WordFilter.GetBlackListed("bad", TestBlacklist, out string filtered);
+        Assert.IsTrue(result);
+        Assert.AreEqual("bad", filtered);
+    }
+
+    [Test]
+    public void DetectsBannedWordCaseInsensitiveViaHomoglyph() {
+        // Uppercase letters are in the homoglyph map for their lowercase counterpart
+        bool result = WordFilter.GetBlackListed("BAD", TestBlacklist, out string filtered);
+        Assert.IsTrue(result);
+        Assert.AreEqual("bad", filtered);
+    }
+
+    [Test]
+    public void ReturnsCleanForInnocentText() {
+        bool result = WordFilter.GetBlackListed("hello world", TestBlacklist, out string filtered);
+        Assert.IsFalse(result);
+        Assert.AreEqual("", filtered);
+    }
+
+    [Test]
+    public void ReturnsCleanForEmptyInput() {
+        bool result = WordFilter.GetBlackListed("", TestBlacklist, out string filtered);
+        Assert.IsFalse(result);
+        Assert.AreEqual("", filtered);
+    }
+
+    [Test]
+    public void SkipsEmptyBlacklistEntries() {
+        var blacklist = new[] { "", null, "bad" };
+        bool result = WordFilter.GetBlackListed("bad", blacklist, out string filtered);
+        Assert.IsTrue(result);
+        Assert.AreEqual("bad", filtered);
+    }
+
+    // --- Text element index mismatch regression tests ---
+    // These test the fix for using text element indices instead of char indices.
+    // Before the fix, multi-byte characters caused SubstringByTextElements
+    // to receive a char offset, leading to wrong trigram lookups or crashes.
+
+    [Test]
+    public void DoesNotCrashOnInputWithEmoji() {
+        // Emoji are multi-char text elements (surrogate pairs).
+        // With the old char-index bug, this could throw ArgumentOutOfRangeException.
+        Assert.DoesNotThrow(() => {
+            WordFilter.GetBlackListed("😀😁😂 hello 😃😄", TestBlacklist, out _);
+        });
+    }
+
+    [Test]
+    public void DoesNotCrashOnInputWithCombiningMarks() {
+        // Combining characters: e + combining acute = é as two chars but one text element.
+        string input = "e\u0301vile\u0301"; // évileé
+        Assert.DoesNotThrow(() => {
+            WordFilter.GetBlackListed(input, TestBlacklist, out _);
+        });
+    }
+
+    [Test]
+    public void DetectsBannedWordAfterEmoji() {
+        // The banned word appears after multi-byte emoji characters.
+        // If text element index tracking is wrong, the trigram check will
+        // read wrong positions and either crash or miss the match.
+        bool result = WordFilter.GetBlackListed("😀😁 bad", TestBlacklist, out string filtered);
+        Assert.IsTrue(result);
+        Assert.AreEqual("bad", filtered);
+    }
+
+    [Test]
+    public void DetectsBannedWordSurroundedByEmoji() {
+        bool result = WordFilter.GetBlackListed("😀bad😁", TestBlacklist, out string filtered);
+        Assert.IsTrue(result);
+        Assert.AreEqual("bad", filtered);
+    }
+
+    [Test]
+    public void DetectsBannedWordWithMixedUnicodeAndAscii() {
+        // Mix of multi-char text elements and ASCII
+        bool result = WordFilter.GetBlackListed("test 🎮 evil 🎮 end", TestBlacklist, out string filtered);
+        Assert.IsTrue(result);
+        Assert.AreEqual("evil", filtered);
+    }
+
+    [Test]
+    public void DoesNotCrashOnEmojiOnlyInput() {
+        Assert.DoesNotThrow(() => {
+            WordFilter.GetBlackListed("🏳️‍🌈🇺🇸👨‍👩‍👧‍👦", TestBlacklist, out _);
+        });
+    }
+
+    [Test]
+    public void DoesNotFalsePositiveOnEmojiSequences() {
+        // Emoji-only strings should never match ASCII banned words
+        bool result = WordFilter.GetBlackListed("🅱🅰🅳", TestBlacklist, out _);
+        Assert.IsFalse(result);
+    }
+
+    // --- Homoglyph detection ---
+
+    [Test]
+    public void DetectsHomoglyphSubstitution() {
+        // 'ⅇ' (U+2147, double-struck italic small e) is in the homoglyph map for 'e'
+        bool result = WordFilter.GetBlackListed("ⅇvil", TestBlacklist, out string filtered);
+        Assert.IsTrue(result);
+        Assert.AreEqual("evil", filtered);
+    }
+
+    // --- Rich text stripping ---
+
+    [Test]
+    public void DetectsBannedWordHiddenInRichTextWithStripping() {
+        bool result = WordFilter.GetBlackListed("<color=red>b</color>ad", TestBlacklist, out string filtered, stripRichText: true);
+        Assert.IsTrue(result);
+        Assert.AreEqual("bad", filtered);
+    }
+
+    [Test]
+    public void RichTextNotStrippedByDefault() {
+        // Without stripRichText, tags remain and may prevent matching
+        // (the tags disrupt the character sequence)
+        bool result = WordFilter.GetBlackListed("<color=red>bad</color>", TestBlacklist, out _, stripRichText: false);
+        // With tags in place, the characters <, c, o, l, ... disrupt matching
+        // This just verifies the flag is respected — exact behavior depends on trigram interactions
+        Assert.DoesNotThrow(() => {
+            WordFilter.GetBlackListed("<color=red>bad</color>", TestBlacklist, out _, stripRichText: false);
+        });
+    }
+}
+
+}

--- a/Packages/com.naelstrof.word-filter/Tests/com.naelstrof.word-filter.tests.asmdef
+++ b/Packages/com.naelstrof.word-filter/Tests/com.naelstrof.word-filter.tests.asmdef
@@ -1,0 +1,20 @@
+{
+    "name": "com.naelstrof.word-filter.tests",
+    "rootNamespace": "",
+    "references": [
+        "com.naelstrof.word-filter"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Packages/com.naelstrof.word-filter/WordFilter.cs
+++ b/Packages/com.naelstrof.word-filter/WordFilter.cs
@@ -359,14 +359,14 @@ static Dictionary<char, string> homoglyphs = new() {
                 continue;
             }
             int state = 0;
+            int textElementIndex = 0;
             var enumerator = StringInfo.GetTextElementEnumerator(name);
             while (enumerator.MoveNext()) {
-                var index = enumerator.ElementIndex;
                 var element = enumerator.GetTextElement();
                 var character = word[state];
-                if (CheckHomoglyph(character, element) && !CheckTrigram(info, index, word)) {
+                if (CheckHomoglyph(character, element) && !CheckTrigram(info, textElementIndex, word)) {
                     state++;
-                } else if (CheckTrigram(info, index, word)) {
+                } else if (CheckTrigram(info, textElementIndex, word)) {
                     if (state > 0) {
                         state--;
                     }
@@ -375,6 +375,7 @@ static Dictionary<char, string> homoglyphs = new() {
                     filtered = word;
                     return true;
                 }
+                textElementIndex++;
             }
         }
         filtered = "";


### PR DESCRIPTION
## Summary

- **Bug:** `GetBlackListed` in `WordFilter.cs` uses `enumerator.ElementIndex` to get the current position, but `ElementIndex` returns a **char offset** into the underlying string. This value is then passed to `CheckTrigram`, which calls `StringInfo.SubstringByTextElements(index, count)` — a method that expects a **text element index** (grapheme cluster index), not a char offset.
- For pure ASCII input the two values are identical, so the bug is invisible. But for any input containing multi-byte characters (emoji, surrogate pairs, combining marks), the char offset diverges from the text element index, producing wrong trigram lookups or throwing `ArgumentOutOfRangeException`.
- **Fix:** Track the text element index with a separate counter that increments on each `MoveNext()` call, and pass that counter to `CheckTrigram` instead of `enumerator.ElementIndex`.

## Test plan

- [ ] Verify word filter still catches blacklisted words in plain ASCII names
- [ ] Test with names containing emoji or combining characters (e.g., `"t💀est"`) to confirm no `ArgumentOutOfRangeException`
- [ ] Confirm trigram checks use correct text element positions for multi-byte input

🤖 Generated with [Claude Code](https://claude.com/claude-code)