### PR TITLE
Fix word filter bypass via zero-width Unicode characters

### DIFF
--- a/Packages/com.naelstrof.word-filter/WordFilter.cs
+++ b/Packages/com.naelstrof.word-filter/WordFilter.cs
@@ -287,6 +287,32 @@ static Dictionary<char, string> homoglyphs = new() {
 };
     
 #endregion
+    private static string StripInvisibleCharacters(string input) {
+        var sb = new System.Text.StringBuilder(input.Length);
+        foreach (char c in input) {
+            switch (c) {
+                case '\u200B': // zero-width space
+                case '\u200C': // zero-width non-joiner
+                case '\u200D': // zero-width joiner
+                case '\uFEFF': // zero-width no-break space (BOM)
+                case '\u00AD': // soft hyphen
+                case '\u200E': // left-to-right mark
+                case '\u200F': // right-to-left mark
+                case '\u2060': // word joiner
+                case '\u2061': // function application
+                case '\u2062': // invisible times
+                case '\u2063': // invisible separator
+                case '\u2064': // invisible plus
+                case '\u034F': // combining grapheme joiner
+                    continue;
+                default:
+                    sb.Append(c);
+                    break;
+            }
+        }
+        return sb.ToString();
+    }
+
     private static bool CheckTrigram(StringInfo info, int index, string bannedWord) {
         var character = info.SubstringByTextElements(index, 1);
         if (info.LengthInTextElements > index + 2) {
@@ -353,6 +379,7 @@ static Dictionary<char, string> homoglyphs = new() {
         if (stripRichText) {
             name = name.StripRichText();
         }
+        name = StripInvisibleCharacters(name);
         StringInfo info = new StringInfo(name);
         foreach (var word in blacklist) {
             if (string.IsNullOrEmpty(word)) {


### PR DESCRIPTION
## Summary

- **Vulnerability:** The `GetBlackListed` method in `WordFilter.cs` can be bypassed by inserting zero-width Unicode characters (e.g., U+200D zero-width joiner, U+200B zero-width space) between letters of banned words. The text still renders identically to humans, but the filter fails to match.
- **Fix:** Adds a `StripInvisibleCharacters()` helper that removes 13 common invisible/zero-width Unicode characters before blacklist matching. The method is called at the start of `GetBlackListed`, after rich-text stripping but before `StringInfo` processing.

### Characters stripped

| Codepoint | Name |
|-----------|------|
| U+200B | Zero-width space |
| U+200C | Zero-width non-joiner |
| U+200D | Zero-width joiner |
| U+FEFF | Zero-width no-break space (BOM) |
| U+00AD | Soft hyphen |
| U+200E | Left-to-right mark |
| U+200F | Right-to-left mark |
| U+2060 | Word joiner |
| U+2061 | Function application |
| U+2062 | Invisible times |
| U+2063 | Invisible separator |
| U+2064 | Invisible plus |
| U+034F | Combining grapheme joiner |

## Test plan

- [ ] Verify that inserting zero-width characters (e.g., `b\u200Danned`) between letters of a blacklisted word is now correctly detected
- [ ] Verify that normal (non-obfuscated) blacklisted words are still caught
- [ ] Verify that legitimate text containing zero-width characters (e.g., emoji ZWJ sequences) does not cause false positives in unrelated words
- [ ] Verify no regression in existing homoglyph and trigram detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)