### PR TITLE
Fix StripRichText bypasses from missing rich text tags

### DIFF
--- a/Packages/com.naelstrof.word-filter/RichTextHelper.cs
+++ b/Packages/com.naelstrof.word-filter/RichTextHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text;
@@ -25,7 +25,7 @@ namespace WordFilter {
             "blue",
             "white",
         };
-        
+
         private static readonly List<string> knownOpeningTags = new() {
             "i",
             "b",
@@ -35,8 +35,11 @@ namespace WordFilter {
             "sub",
             "sup",
             "u",
+            "nobr",
+            "noparse",
+            "page",
         };
-        
+
         private static readonly List<string> knownClosingTags = new () {
             "color",
             "i",
@@ -46,6 +49,23 @@ namespace WordFilter {
             "sub",
             "sup",
             "u",
+            "size",
+            "font",
+            "sprite",
+            "mark",
+            "align",
+            "indent",
+            "link",
+            "lowercase",
+            "uppercase",
+            "smallcaps",
+            "margin",
+            "nobr",
+            "noparse",
+            "pos",
+            "space",
+            "voffset",
+            "width",
         };
 
         private static bool TryParseStartColorTag(string tag) {
@@ -72,6 +92,24 @@ namespace WordFilter {
             return true;
         }
 
+        private static readonly List<string> knownParameterizedTags = new() {
+            "size",
+            "font",
+            "sprite",
+            "mark",
+            "align",
+            "indent",
+            "link",
+            "lowercase",
+            "uppercase",
+            "smallcaps",
+            "margin",
+            "pos",
+            "space",
+            "voffset",
+            "width",
+        };
+
         private static bool ParseStartTag(ReadOnlySpan<char> tag) {
             if (TryParseHex(tag)) {
                 return true;
@@ -81,12 +119,17 @@ namespace WordFilter {
             if (tag.StartsWith("color")) {
                 return TryParseStartColorTag(tagString);
             }
+            foreach (var paramTag in knownParameterizedTags) {
+                if (tagString.StartsWith(paramTag)) {
+                    return true;
+                }
+            }
             return knownOpeningTags.Contains(tagString);
         }
         private static bool ParseEndTag(ReadOnlySpan<char> tag) {
             return knownClosingTags.Contains(tag.ToString());
         }
-        
+
         public static string StripRichText(this string text) {
             var builder = new StringBuilder();
             var i = 0;


### PR DESCRIPTION
## Summary
- `StripRichText` in `RichTextHelper.cs` only recognized a small subset of Unity/TextMeshPro rich text tags (`i`, `b`, `br`, `s`, `strikethrough`, `sub`, `sup`, `u`, `color`). Many commonly-used tags were missing, allowing them to be used to obfuscate filtered content and bypass the word filter when `stripRichText` is enabled.
- Added missing tags (`nobr`, `noparse`, `page`) to `knownOpeningTags` and 17 missing tags (`size`, `font`, `sprite`, `mark`, `align`, `indent`, `link`, `lowercase`, `uppercase`, `smallcaps`, `margin`, `nobr`, `noparse`, `pos`, `space`, `voffset`, `width`) to `knownClosingTags`.
- Introduced a `knownParameterizedTags` list and a `StartsWith` loop in `ParseStartTag` so that opening tags with parameters (e.g. `<size=20>`, `<font=Arial>`, `<margin=10>`) are properly recognized and stripped, matching the existing pattern used for `color`.

## Test plan
- [ ] Verify that basic rich text stripping still works for existing tags (e.g. `<b>`, `<i>`, `<color=red>`)
- [ ] Verify that previously-unhandled tags like `<size=20>text</size>`, `<font=Arial>text</font>`, `<mark=#ff0000>text</mark>`, `<lowercase>TEXT</lowercase>` are now properly stripped
- [ ] Verify that non-rich-text angle bracket content (e.g. `<hello>`) is preserved and not stripped

🤖 Generated with [Claude Code](https://claude.com/claude-code)